### PR TITLE
fix(custom-webpack): support exporting function in config written in TS

### DIFF
--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -316,7 +316,7 @@ module.exports = (config, options) => {
 Alternatively, using TypeScript:
 
 ```ts
-import { CustomWebpackBrowserSchema } from '@angular-builders/custom-webpack/dist';
+import { CustomWebpackBrowserSchema } from '@angular-builders/custom-webpack';
 import * as webpack from 'webpack';
 import * as pkg from './package.json';
 

--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -313,6 +313,24 @@ module.exports = (config, options) => {
 };
 ```
 
+Alternatively, using TypeScript:
+
+```ts
+import { CustomWebpackBrowserSchema } from '@angular-builders/custom-webpack/dist';
+import * as webpack from 'webpack';
+import * as pkg from './package.json';
+
+export default (config: webpack.Configuration, options: CustomWebpackBrowserSchema) => {
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      APP_VERSION: JSON.stringify(pkg.version),
+    })
+  );
+
+  return config;
+};
+```
+
 It's also possible to export an asynchronous factory (factory that returns a `Promise` object). Let's look at the following example:
 
 ```js

--- a/packages/custom-webpack/examples/full-cycle-app/angular.json
+++ b/packages/custom-webpack/examples/full-cycle-app/angular.json
@@ -39,7 +39,7 @@
           "configurations": {
             "production": {
               "customWebpackConfig": {
-                "path": "./func-webpack.config.js"
+                "path": "./func-webpack.config.ts"
               },
               "fileReplacements": [
                 {

--- a/packages/custom-webpack/examples/full-cycle-app/func-webpack.config.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/func-webpack.config.ts
@@ -1,4 +1,4 @@
-import { Configuration } as webpack from 'webpack';
+import { Configuration } from 'webpack';
 import { CustomWebpackBrowserSchema } from '@angular-builders/custom-webpack';
 import * as HtmlWebpackPlugin from 'html-webpack-plugin';
 

--- a/packages/custom-webpack/examples/full-cycle-app/func-webpack.config.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/func-webpack.config.ts
@@ -1,10 +1,11 @@
 import { Configuration } as webpack from 'webpack';
+import { CustomWebpackBrowserSchema } from '@angular-builders/custom-webpack';
 import * as HtmlWebpackPlugin from 'html-webpack-plugin';
 
 /**
  * This is where you define a function that modifies your webpack config
  */
-export default (cfg: Configuration) => {
+export default (cfg: Configuration, opts: CustomWebpackBrowserSchema) => {
   cfg.plugins.push(
     new HtmlWebpackPlugin({
       filename: 'footer.html',

--- a/packages/custom-webpack/examples/full-cycle-app/func-webpack.config.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/func-webpack.config.ts
@@ -1,10 +1,10 @@
-import * as webpack from 'webpack';
+import { Configuration } as webpack from 'webpack';
 import * as HtmlWebpackPlugin from 'html-webpack-plugin';
 
 /**
  * This is where you define a function that modifies your webpack config
  */
-export default (cfg: webpack.Configuration) => {
+export default (cfg: Configuration) => {
   cfg.plugins.push(
     new HtmlWebpackPlugin({
       filename: 'footer.html',

--- a/packages/custom-webpack/examples/full-cycle-app/func-webpack.config.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/func-webpack.config.ts
@@ -1,9 +1,10 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+import * as webpack from 'webpack';
+import * as HtmlWebpackPlugin from 'html-webpack-plugin';
 
 /**
  * This is where you define a function that modifies your webpack config
  */
-module.exports = cfg => {
+export default (cfg: webpack.Configuration) => {
   cfg.plugins.push(
     new HtmlWebpackPlugin({
       filename: 'footer.html',

--- a/packages/custom-webpack/src/custom-webpack-builder.ts
+++ b/packages/custom-webpack/src/custom-webpack-builder.ts
@@ -67,9 +67,5 @@ function resolveCustomWebpackConfig(path: string): CustomWebpackConfig {
   // `module.exports = { ... }`. And the second one is:
   // `export default { ... }`. The ESM format is compiled into:
   // `{ default: { ... } }`
-  if (typeof customWebpackConfig.default === 'object') {
-    return customWebpackConfig.default;
-  }
-
-  return customWebpackConfig;
+  return customWebpackConfig.default || customWebpackConfig;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

I noticed that TypeScript support was recently added, so I tried it out. It didn't seem to work with my config, and I am pretty sure it's because I am exporting a function rather than an object. The code that was added to support TypeScript only seems to test for objects before my PR.

Also, apologies, I couldn't find any tests to modify to account for my fix. You'll have to point them out to me if they exist.

## What is the new behavior?

Exported function works with TypeScript config files.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I should also point out that I couldn't get `module.exports` syntax to work at all. I think that would require change to the tsconfig, e.g. [`esModuleInterop` or something as described on the Webpack documentation](https://webpack.js.org/configuration/configuration-languages/). I didn't try to fix that, though.