### PR TITLE
fix(jest): remove local storage mock

### DIFF
--- a/packages/jest/src/jest-config/global-mocks.ts
+++ b/packages/jest/src/jest-config/global-mocks.ts
@@ -1,17 +1,5 @@
 global['CSS'] = null;
 
-const mock = () => {
-  let storage = {};
-  return {
-    getItem: (key: string) => (key in storage ? storage[key] : null),
-    setItem: (key: string, value: any) => (storage[key] = value || ''),
-    removeItem: (key: string) => delete storage[key],
-    clear: () => (storage = {}),
-  };
-};
-
-Object.defineProperty(window, 'localStorage', { value: mock() });
-Object.defineProperty(window, 'sessionStorage', { value: mock() });
 Object.defineProperty(document, 'doctype', {
   value: '<!DOCTYPE html>',
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently the Jest builder is adding a mock for local storage and session storage. But this mock has missing features like the `length` property or a `keys` method.
This breaks unit tests which are using the localForage library because it uses the `length` property and `keys` method.

Issue Number: N/A

## What is the new behavior?

We remove the mock altogether because as the builder is requiring Jest >= 26 which requires the newest jsdom version (16) which itself has its own implementation of local storage and session storage. The implementation of jsdom has all missing features described above, so we don't need the mock anymore.

Jest 26 has jsdom 16: https://github.com/facebook/jest/releases/tag/v26.0.0
jsdom has a local storage and session storage implementation since 11.12.0: https://github.com/jsdom/jsdom/blob/master/Changelog.md#11120

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

I would say it is not a breaking change because the implementation of the local storage and session storage of jsdom is the same as the current mock but with a more complete API.

## Other information
