### PR TITLE
Use application tsconfig file for indexTransform and customWebpackConfig

### DIFF
--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -261,35 +261,35 @@ The following properties are available:
    In more complicated cases you'd probably want to [use a function](#custom-webpack-config-function) instead of an object.
 - `mergeRules`: webpack config merge rules, as described [here](https://github.com/survivejs/webpack-merge#mergewithrules). Defaults to:
 
-```ts
-{
-  module: {
-    rules: {
-      test: "match",
-      use: {
-        loader: "match",
-        options: "merge",
+  ```ts
+  {
+    module: {
+      rules: {
+        test: "match",
+        use: {
+          loader: "match",
+          options: "merge",
+        },
       },
     },
-  },
-};
-```
+  };
+  ```
 
 - `replaceDuplicatePlugins`: Defaults to `false`. If `true`, the plugins in custom webpack config will replace the corresponding plugins in default Angular CLI webpack configuration. If `false`, the [default behavior](#merging-plugins-configuration) will be applied.
   **Note that if `true`, this option will override `mergeRules` for `plugins` field.**
 
-Webpack configuration can be also written in TypeScript. Given the following example:
+Webpack configuration can be also written in TypeScript. In this case, it is the appliaction's `tsConfig` file which will be use by `tsnode` for `customWebpackConfig.ts` execution. Given the following example:
 
 ```ts
 // extra-webpack.config.ts
-import * as webpack from 'webpack';
+import { Configuration } from 'webpack';
 
 export default {
   output: {
     library: 'shop',
     libraryTarget: 'umd',
   },
-} as webpack.Configuration;
+} as Configuration;
 ```
 
 Do not forget to specify the correct path to this file:
@@ -421,6 +421,7 @@ module.exports = async config => {
 Since Angular 8 `index.html` is not generated as part of the Webpack build. If you want to modify your `index.html` you should use `indexTransform` option.  
 `indexTransform` is a path (relative to workspace root) to a `.js` or `.ts` file that exports transformation function for `index.html`.  
 Function signature is as following:
+If `indexTransform` is writes in TypeScript, it is the application's `tsConfig` file which will be use by `tsnode` for `indexTransform.ts` execution.
 
 ```typescript
 (options: TargetOptions, indexHtmlContent: string) => string|Promise<string>;

--- a/packages/custom-webpack/examples/full-cycle-app/angular.json
+++ b/packages/custom-webpack/examples/full-cycle-app/angular.json
@@ -50,7 +50,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "namedChunks": false,
               "aot": true,
               "extractLicenses": true,

--- a/packages/custom-webpack/examples/full-cycle-app/angular.json
+++ b/packages/custom-webpack/examples/full-cycle-app/angular.json
@@ -18,7 +18,10 @@
           "builder": "@angular-builders/custom-webpack:browser",
           "options": {
             "customWebpackConfig": {
-              "path": "./extra-webpack.config.ts"
+              "path": "./extra-webpack.config.ts",
+              "mergeRules": {
+                "plugins": "prepend"
+              }
             },
             "indexTransform": "./index-html.transform.js",
             "outputPath": "dist/full-cycle-app",

--- a/packages/custom-webpack/examples/full-cycle-app/e2e/protractor.conf.js
+++ b/packages/custom-webpack/examples/full-cycle-app/e2e/protractor.conf.js
@@ -19,12 +19,20 @@ exports.config = {
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000,
-    print: function() {},
+    print: function () {},
   },
   onPrepare() {
+    const tsConfig = require('path').join(__dirname, './tsconfig.json');
     require('ts-node').register({
-      project: require('path').join(__dirname, './tsconfig.json'),
+      project: tsConfig,
     });
+
+    // Register paths in tsConfig
+    const tsconfigPaths = require('tsconfig-paths');
+    const { absoluteBaseUrl: baseUrl, paths } = tsconfigPaths.loadConfig(tsConfig);
+    if (baseUrl && paths) {
+      tsconfigPaths.register({ baseUrl, paths });
+    }
     jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
   },
 };

--- a/packages/custom-webpack/examples/full-cycle-app/e2e/src/app.e2e-spec-itwcw.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/e2e/src/app.e2e-spec-itwcw.ts
@@ -1,3 +1,4 @@
+import { version } from '@project';
 import { AppPage } from './app.po';
 
 describe('workspace-project App', () => {
@@ -10,5 +11,10 @@ describe('workspace-project App', () => {
   it('should display paragraph coming from transform function', async () => {
     await page.navigateTo();
     expect(await page.getParagraphText()).toEqual('Configuration: itwcw');
+  });
+
+  it('should display version in div with `version` css class', async () => {
+    await page.navigateTo();
+    expect(await page.getVersionText()).toEqual(version);
   });
 });

--- a/packages/custom-webpack/examples/full-cycle-app/e2e/src/app.e2e-spec-prod.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/e2e/src/app.e2e-spec-prod.ts
@@ -1,3 +1,4 @@
+import { version } from '@project';
 import { AppPage } from './app.po';
 
 describe('workspace-project App', () => {
@@ -10,5 +11,10 @@ describe('workspace-project App', () => {
   it('should display paragraph coming from transform function', async () => {
     await page.navigateTo();
     expect(await page.getParagraphText()).toEqual('Configuration: production');
+  });
+
+  it('should display version in div with `version` css class', async () => {
+    await page.navigateTo();
+    expect(await page.getVersionText()).toEqual(version);
   });
 });

--- a/packages/custom-webpack/examples/full-cycle-app/e2e/src/app.e2e-spec.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/e2e/src/app.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { version } from '@project';
 import { AppPage } from './app.po';
 
 describe('workspace-project App', () => {
@@ -10,5 +11,10 @@ describe('workspace-project App', () => {
   it('should display generated Hello World div', async () => {
     await page.navigateTo();
     expect(await page.getDivText()).toEqual('Hello World');
+  });
+
+  it('should display version in div with `version` css class', async () => {
+    await page.navigateTo();
+    expect(await page.getVersionText()).toEqual(version);
   });
 });

--- a/packages/custom-webpack/examples/full-cycle-app/e2e/src/app.po.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/e2e/src/app.po.ts
@@ -12,4 +12,8 @@ export class AppPage {
   getParagraphText() {
     return element(by.css('body>p')).getText();
   }
+
+  getVersionText() {
+    return element(by.css('body .version')).getText();
+  }
 }

--- a/packages/custom-webpack/examples/full-cycle-app/extra-webpack.config.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/extra-webpack.config.ts
@@ -1,5 +1,6 @@
-import * as webpack from 'webpack';
+import { Configuration, DefinePlugin } from 'webpack';
 import * as HtmlWebpackPlugin from 'html-webpack-plugin';
+import { version } from '@project';
 
 /**
  * This is where you define your additional webpack configuration items to be appended to
@@ -11,5 +12,8 @@ export default {
       filename: 'footer.html',
       template: 'src/footer-template.html',
     }),
+    new DefinePlugin({
+      APP_VERSION: JSON.stringify(version),
+    }),
   ],
-} as webpack.Configuration;
+} as Configuration;

--- a/packages/custom-webpack/examples/full-cycle-app/func-webpack.config.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/func-webpack.config.ts
@@ -1,15 +1,23 @@
-import { Configuration } from 'webpack';
+import { Configuration, DefinePlugin } from 'webpack';
 import { CustomWebpackBrowserSchema, TargetOptions } from '@angular-builders/custom-webpack';
 import * as HtmlWebpackPlugin from 'html-webpack-plugin';
+import { version } from '@project';
 
 /**
  * This is where you define a function that modifies your webpack config
  */
-export default (cfg: Configuration, opts: CustomWebpackBrowserSchema, targetOptions: TargetOptions) => {
+export default (
+  cfg: Configuration,
+  opts: CustomWebpackBrowserSchema,
+  targetOptions: TargetOptions
+) => {
   cfg.plugins.push(
     new HtmlWebpackPlugin({
       filename: 'footer.html',
       template: 'src/footer-template.html',
+    }),
+    new DefinePlugin({
+      APP_VERSION: JSON.stringify(version),
     })
   );
 

--- a/packages/custom-webpack/examples/full-cycle-app/src/app/app.component.html
+++ b/packages/custom-webpack/examples/full-cycle-app/src/app/app.component.html
@@ -1,5 +1,5 @@
 <!--The content below is only a placeholder and can be replaced.-->
-<div style="text-align:center">
+<div style="text-align: center">
   <h1>Welcome to {{ title }}!</h1>
   <img
     width="300"
@@ -23,3 +23,5 @@
     <h2><a target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
   </li>
 </ul>
+
+<div class="version">{{ version }}</div>

--- a/packages/custom-webpack/examples/full-cycle-app/src/app/app.component.scss
+++ b/packages/custom-webpack/examples/full-cycle-app/src/app/app.component.scss
@@ -1,0 +1,6 @@
+.version {
+    padding: 0.625rem;
+    background-color: lightgray;
+    color: black;
+    text-align: right;
+}

--- a/packages/custom-webpack/examples/full-cycle-app/src/app/app.component.spec.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/src/app/app.component.spec.ts
@@ -1,8 +1,11 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
-import { AppComponent } from './app.component';
+import { AppComponent } from '@app/app.component';
+
 describe('AppComponent', () => {
   beforeEach(
     waitForAsync(() => {
+      Object.defineProperty(window, 'APP_VERSION', { value: `fake version`, writable: false });
+
       TestBed.configureTestingModule({
         declarations: [AppComponent],
       }).compileComponents();
@@ -31,6 +34,15 @@ describe('AppComponent', () => {
       fixture.detectChanges();
       const compiled = fixture.debugElement.nativeElement;
       expect(compiled.querySelector('h1').textContent).toContain('Welcome to full-cycle-app!');
+    })
+  );
+  it(
+    'should render `version` in div with `version` css class',
+    waitForAsync(() => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      const compiled = fixture.debugElement.nativeElement;
+      expect(compiled.querySelector('.version').textContent).toContain('fake version');
     })
   );
 });

--- a/packages/custom-webpack/examples/full-cycle-app/src/app/app.component.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+declare const APP_VERSION: string;
 
 @Component({
   selector: 'app-root',
@@ -7,4 +8,5 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'full-cycle-app';
+  version = APP_VERSION;
 }

--- a/packages/custom-webpack/examples/full-cycle-app/src/app/app.module.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/src/app/app.module.ts
@@ -1,7 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-
-import { AppComponent } from './app.component';
+import { AppComponent } from '@app/app.component';
 
 @NgModule({
   declarations: [AppComponent],

--- a/packages/custom-webpack/examples/full-cycle-app/src/main.ts
+++ b/packages/custom-webpack/examples/full-cycle-app/src/main.ts
@@ -1,8 +1,7 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
-import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
+import { AppModule } from '@app/app.module';
+import { environment } from '@environment';
 
 if (environment.production) {
   enableProdMode();

--- a/packages/custom-webpack/examples/full-cycle-app/tsconfig.base.json
+++ b/packages/custom-webpack/examples/full-cycle-app/tsconfig.base.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "resolveJsonModule": true,
     "importHelpers": true,
     "target": "es2015",
     "typeRoots": [
@@ -17,6 +18,11 @@
     "lib": [
       "es2018",
       "dom"
-    ]
+    ],
+    "paths": {
+      "@app/*": ["src/app/*"],
+      "@environment": ["src/environments/environment.ts"],
+      "@project": ["package.json"]
+    }
   }
 }

--- a/packages/custom-webpack/examples/sanity-app/angular.json
+++ b/packages/custom-webpack/examples/sanity-app/angular.json
@@ -42,7 +42,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "namedChunks": false,
               "aot": true,
               "extractLicenses": true,

--- a/packages/custom-webpack/package.json
+++ b/packages/custom-webpack/package.json
@@ -42,6 +42,7 @@
     "@angular-devkit/core": "^11.0.0",
     "lodash": "^4.17.15",
     "ts-node": "^9.0.0",
+    "tsconfig-paths": "^3.9.0",
     "webpack-merge": "^5.7.3"
   }
 }

--- a/packages/custom-webpack/src/custom-webpack-builder.ts
+++ b/packages/custom-webpack/src/custom-webpack-builder.ts
@@ -37,7 +37,8 @@ export class CustomWebpackBuilder {
 
     const webpackConfigPath = config.path || defaultWebpackConfigPath;
     const path = `${getSystemPath(root)}/${webpackConfigPath}`;
-    const configOrFactoryOrPromise = resolveCustomWebpackConfig(path);
+    const tsConfig = `${getSystemPath(root)}/${buildOptions.tsConfig}`;
+    const configOrFactoryOrPromise = resolveCustomWebpackConfig(path, tsConfig);
 
     if (typeof configOrFactoryOrPromise === 'function') {
       // That exported function can be synchronous either
@@ -63,8 +64,8 @@ export class CustomWebpackBuilder {
   }
 }
 
-function resolveCustomWebpackConfig(path: string): CustomWebpackConfig {
-  tsNodeRegister(path);
+function resolveCustomWebpackConfig(path: string, tsConfig: string): CustomWebpackConfig {
+  tsNodeRegister(path, tsConfig);
 
   const customWebpackConfig = require(path);
   // If the user provides a configuration in TS file

--- a/packages/custom-webpack/src/custom-webpack-schema.ts
+++ b/packages/custom-webpack/src/custom-webpack-schema.ts
@@ -3,4 +3,5 @@ import { CustomWebpackBuilderConfig } from './custom-webpack-builder-config';
 export interface CustomWebpackSchema {
   customWebpackConfig: CustomWebpackBuilderConfig;
   indexTransform: string;
+  tsConfig?: string;
 }

--- a/packages/custom-webpack/src/transform-factories.ts
+++ b/packages/custom-webpack/src/transform-factories.ts
@@ -26,9 +26,9 @@ export const customWebpackConfigTransformFactory: (
 export const indexHtmlTransformFactory: (
   options: CustomWebpackSchema,
   context: BuilderContext
-) => IndexHtmlTransform = ({ indexTransform }, { workspaceRoot, target }) => {
+) => IndexHtmlTransform = ({ indexTransform, tsConfig }, { workspaceRoot, target }) => {
   if (!indexTransform) return null;
-  tsNodeRegister(indexTransform);
+  tsNodeRegister(indexTransform, `${getSystemPath(normalize(workspaceRoot))}/${tsConfig}`);
   const indexModule = require(`${getSystemPath(normalize(workspaceRoot))}/${indexTransform}`);
   const transform = indexModule.default || indexModule;
   return async (indexHtml: string) => transform(target, indexHtml);

--- a/packages/custom-webpack/src/utils.ts
+++ b/packages/custom-webpack/src/utils.ts
@@ -16,5 +16,12 @@ export function tsNodeRegister(file: string = '', tsConfig?: string) {
         ],
       },
     });
+
+    // Register paths in tsConfig
+    const tsconfigPaths = require('tsconfig-paths');
+    const { absoluteBaseUrl: baseUrl, paths } = tsconfigPaths.loadConfig(tsConfig);
+    if (baseUrl && paths) {
+      tsconfigPaths.register({ baseUrl, paths });
+    }
   }
 }

--- a/packages/custom-webpack/src/utils.ts
+++ b/packages/custom-webpack/src/utils.ts
@@ -3,12 +3,17 @@
  * @param file: file name or file directory are allowed
  * @todo tsNodeRegistration: require ts-node if file extension is TypeScript
  */
-export function tsNodeRegister(file: string = '') {
+export function tsNodeRegister(file: string = '', tsConfig?: string) {
   if (file && file.endsWith('.ts')) {
     // Register TS compiler lazily
     require('ts-node').register({
+      project: tsConfig,
       compilerOptions: {
-        module: 'commonjs',
+        module: 'CommonJS',
+        target: 'ESNext', // NOTE: because interpreter is `node`, it is not necessary to spend a lot time for compiling
+        types: [
+          'node', // NOTE: `node` is added because users scripts can also use pure node's packages as webpack or others
+        ],
       },
     });
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The application's `tsconfig` is ignore. Accordingly, `indexTransform` and `customWebpackConfig` cannot use project configuration for custom modules for example

Issue Number: #607 #749 

## What is the new behavior?
The application's `tsconfig` is now use. `indexTransform` and `customWebpackConfig` can now use all the application resources.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
