### PR TITLE
fix: allow merging loader name with loader object

### DIFF
--- a/packages/custom-webpack/package.json
+++ b/packages/custom-webpack/package.json
@@ -42,6 +42,6 @@
     "@angular-devkit/core": "^11.0.0",
     "lodash": "^4.17.15",
     "ts-node": "^9.0.0",
-    "webpack-merge": "^5.7.2"
+    "webpack-merge": "^5.7.3"
   }
 }

--- a/packages/custom-webpack/src/webpack-config-merger.spec.ts
+++ b/packages/custom-webpack/src/webpack-config-merger.spec.ts
@@ -306,4 +306,59 @@ describe('Webpack config merger test', () => {
 
     expect(mergeConfigs(conf1, conf2)).toEqual(expected);
   });
+
+  it('should merge loader name with loader object', () => {
+    const conf1 = {
+      module: {
+        rules: [
+          {
+            test: 'some-test',
+            use: ['hello-loader'],
+          },
+        ],
+      },
+    };
+
+    const conf2 = {
+      module: {
+        rules: [
+          {
+            test: 'another-test',
+            use: [
+              {
+                loader: 'another-loader',
+                options: {
+                  someoption: 'hey',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const expected = {
+      module: {
+        rules: [
+          {
+            test: 'some-test',
+            use: ['hello-loader'],
+          },
+          {
+            test: 'another-test',
+            use: [
+              {
+                loader: 'another-loader',
+                options: {
+                  someoption: 'hey',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(mergeConfigs(conf1, conf2)).toEqual(expected);
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Loaders merge might fail because one of Angular loaders is defined as a string and not as an object. More info [here](https://github.com/just-jeb/angular-builders/issues/908#issuecomment-747424538) and [here](https://github.com/survivejs/webpack-merge/issues/170#issue-770082482).

## What is the new behavior?

Builder update to a newer version of webpack-merge in which this issue is fixed.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
