### PR TITLE
ci: allow checkout without the GH token (for forks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,13 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v2
+      - if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_PERSONAL_TOKEN }}
+
+      - if: github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v1
         id: node-modules


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Fork PR builds [fail](https://github.com/just-jeb/angular-builders/pull/879#issuecomment-763161710) because of missing token.

## What is the new behavior?

Fork PR builds use the checkout action without the token.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
