### PR TITLE
fix(jest): sync latest jest-preset-angular

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@angular-devkit/architect": ">=0.1100.0 < 0.1200.0",
     "@angular-devkit/core": "^11.0.0",
-    "jest-preset-angular": "^8.3.2",
+    "jest-preset-angular": "^8.4.0",
     "lodash": "^4.17.15"
   },
   "peerDependencies": {

--- a/packages/jest/src/jest-config/setup.ts
+++ b/packages/jest/src/jest-config/setup.ts
@@ -1,2 +1,2 @@
-import 'jest-preset-angular';
+import 'jest-preset-angular/setup-jest';
 import './global-mocks';


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Other information

With the latest `jest-preset-angular` my console logs and the CI logs are polluted with:
![image](https://user-images.githubusercontent.com/260185/110218287-e1909b00-7e86-11eb-877c-4dc63440f774.png)
and as the dependency is defined as `^8.3.2` I cannot avoid the lock file to be refreshed with `8.4.0`

Thanks in advance