### PR TITLE
fix(custom-webpack): specify possible types of customWebpackConfig values

### DIFF
--- a/packages/custom-webpack/e2e/custom-webpack-config-schema.ts
+++ b/packages/custom-webpack/e2e/custom-webpack-config-schema.ts
@@ -1,19 +1,29 @@
 export const customWebpackConfig = {
-  type: 'object',
   description: 'Custom webpack configuration',
-  properties: {
-    path: { type: 'string', description: 'Path to the custom webpack configuration file' },
-    mergeRules: {
-      type: 'object',
-      description:
-        'Merge rules as described here: https://github.com/survivejs/webpack-merge#mergewithrules',
-    },
-    replaceDuplicatePlugins: {
-      type: 'boolean',
-      description: 'Flag that indicates whether to replace duplicate webpack plugins or not',
-    },
-  },
   default: false,
+  oneOf: [
+    {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Path to the custom webpack configuration file',
+        },
+        mergeRules: {
+          type: 'object',
+          description:
+            'Merge rules as described here: https://github.com/survivejs/webpack-merge#mergewithrules',
+        },
+        replaceDuplicatePlugins: {
+          type: 'boolean',
+          description: 'Flag that indicates whether to replace duplicate webpack plugins or not',
+        },
+      },
+    },
+    {
+      type: 'boolean',
+    },
+  ],
 };
 
 export const indexTransform = {

--- a/packages/custom-webpack/src/schema.ext.json
+++ b/packages/custom-webpack/src/schema.ext.json
@@ -1,15 +1,34 @@
 {
   "properties": {
     "customWebpackConfig": {
-      "type": "object",
       "description": "Custom webpack configuration",
-      "properties": {
-        "path": {"type": "string", "description": "Path to the custom webpack configuration file"},
-        "mergeRules": {"type": "object", "description": "Merge rules as described here: https://github.com/survivejs/webpack-merge#mergewithrules"},
-        "replaceDuplicatePlugins": {"type": "boolean", "description": "Flag that indicates whether to replace duplicate webpack plugins or not"}
-      },
-      "default": false
+      "default": false,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "Path to the custom webpack configuration file"
+            },
+            "mergeRules": {
+              "type": "object",
+              "description": "Merge rules as described here: https://github.com/survivejs/webpack-merge#mergewithrules"
+            },
+            "replaceDuplicatePlugins": {
+              "type": "boolean",
+              "description": "Flag that indicates whether to replace duplicate webpack plugins or not"
+            }
+          }
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
-    "indexTransform": {"type": "string", "description": "Path to the file with index.html transform function" }
+    "indexTransform": {
+      "type": "string",
+      "description": "Path to the file with index.html transform function"
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

At the moment if someone uses this with the latest versions of [Nx](https://nx.dev) and does not specify a `webpack.config.js` the build fails because it requires one.

The reason is how the defaults are being interpreted by the Angular CLI vs Nx schema parser. Right now the `custom-webpack` browser schema defines `customWebpackConfig` to be of type `object` but assigns a boolean value as the default. The Angular CLI is less strict in that it accepts that, while Nx is more strict (I'm working on the Nx side to avoid such edge cases as much as possible).

## What is the new behavior?

This PR adjusts the schema to properly reflect the possible types, basically a `object` or `boolean`. This is achieved with the `oneOf` property in the schema file.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```