### PR TITLE
fix: update jest builder schema to support all the options

### DIFF
--- a/packages/jest/src/schema.json
+++ b/packages/jest/src/schema.json
@@ -16,466 +16,448 @@
       },
       "default": ["getComputedStyle", "doctype", "styleTransform", "matchMedia"]
     },
-    "all": {
-      "description": "The opposite of `onlyChanged`. If `onlyChanged` is set by default, running jest with `--all` will force Jest to run all tests instead of running only tests related to changed files."
-    },
-    "automock": {
-      "description": "Automock all files by default.",
-      "type": "boolean"
-    },
-    "bail": {
-      "alias": "b",
-      "description": "Exit the test suite immediately upon the first failing test.",
-      "type": "boolean"
-    },
-    "browser": {
-      "description": "Respect the \"browser\" field in package.json when resolving modules. Some packages export different versions based on whether they are operating in node.js or a browser.",
-      "type": "boolean"
-    },
-    "cache": {
-      "description": "Whether to use the transform cache. Disable the cache using --no-cache.",
-      "type": "boolean"
-    },
-    "cacheDirectory": {
-      "description": "The directory where Jest should store its cached  dependency information.",
-      "type": "string"
-    },
-    "changedFilesWithAncestor": {
-      "description": "Runs tests related to the current changes and the changes made in the last commit. Behaves similarly to `--onlyChanged`.",
-      "type": "boolean"
-    },
-    "changedSince": {
-      "description": "Runs tests related the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.",
-      "nargs": 1,
-      "type": "string"
-    },
-    "ci": {
-      "default": false,
-      "description": "Whether to run Jest in continuous integration (CI) mode.",
-      "type": "boolean"
-    },
-    "clearCache": {
-      "description": "Clears the configured Jest cache directory and then exits. Default directory can be found by calling jest --showConfig",
-      "type": "boolean"
-    },
-    "clearMocks": {
-      "description": "Automatically clear mock calls and instances between every test. Equivalent to calling jest.clearAllMocks() between each test.",
-      "type": "boolean"
-    },
-    "collectCoverage": {
-      "description": "Alias for --coverage.",
-      "type": "boolean"
-    },
-    "collectCoverageFrom": {
-      "description": "An array of glob patterns indicating a set of files for which coverage information should be collected. If a file matches the specified glob pattern, coverage information will be collected for it even if no tests exist for this file and it's never required in the test suite",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "color": {
-      "description": "Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors.",
-      "type": "boolean"
-    },
-    "colors": {
-      "description": "Alias for `--color`.",
-      "type": "boolean"
-    },
-    "config": {
-      "alias": "c",
-      "description": "The path to a jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project.This can also be a JSON encoded value which Jest will use as configuration.",
-      "type": "string"
-    },
-    "coverage": {
-      "description": "Indicates that test coverage information should be collected and reported in the output.",
-      "type": "boolean"
-    },
-    "coverageDirectory": {
-      "description": "The directory where Jest should output its coverage files.",
-      "type": "string"
-    },
-    "coveragePathIgnorePatterns": {
-      "description": "An array of regexp pattern strings that are matched against all file paths before executing the test. If the file pathmatches any of the patterns, coverage information will be skipped.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "coverageReporters": {
-      "description": "A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter can be used.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "coverageThreshold": {
-      "description": "A JSON string with which will be used to configure minimum threshold enforcement for coverage results",
-      "type": "string"
-    },
-    "debug": {
-      "description": "Print debugging info about your jest config.",
-      "type": "boolean"
-    },
-    "detectLeaks": {
-      "default": false,
-      "description": "**EXPERIMENTAL**: Detect memory leaks in tests. After executing a test, it will try to garbage collect the global object used, and fail if it was leaked",
-      "type": "boolean"
-    },
-    "detectOpenHandles": {
-      "default": false,
-      "description": "Print out remaining open handles preventing Jest from exiting at the end of a test run.",
-      "type": "boolean"
-    },
-    "env": {
-      "description": "The test environment used for all tests. This can point to any file or node module. Examples: `jsdom`, `node` or `path/to/my-environment.js`",
-      "type": "string"
-    },
-    "errorOnDeprecated": {
-      "default": false,
-      "description": "Make calling deprecated APIs throw helpful error messages.",
-      "type": "boolean"
-    },
-    "expand": {
-      "alias": "e",
-      "description": "Use this flag to show full diffs instead of a patch.",
-      "type": "boolean"
-    },
-    "filter": {
-      "description": "Path to a module exporting a filtering function. This method receives a list of tests which can be manipulated to exclude tests from running. Especially useful when used in conjunction with a testing infrastructure to filter known broken tests.",
-      "type": "string"
-    },
-    "findRelatedTests": {
-      "description": "Find related tests for a list of source files that were passed in as arguments. Useful for pre-commit hook integration to run the minimal amount of tests necessary.",
-      "type": "boolean"
-    },
-    "forceExit": {
-      "description": "Force Jest to exit after all tests have completed running. This is useful when resources set up by test code cannot be adequately cleaned up.",
-      "type": "boolean"
-    },
-    "globalSetup": {
-      "description": "The path to a module that runs before All Tests.",
-      "type": "string"
-    },
-    "globalTeardown": {
-      "description": "The path to a module that runs after All Tests.",
-      "type": "string"
-    },
-    "globals": {
-      "description": "A JSON string with map of global variables that need to be available in all test environments.",
-      "type": "string"
-    },
-    "haste": {
-      "description": "A JSON string with map of variables for the haste module system",
-      "type": "string"
-    },
-    "init": {
-      "description": "Generate a basic configuration file",
-      "type": "boolean"
-    },
-    "json": {
-      "description": "Prints the test results in JSON. This mode will send all other test output and user messages to stderr.",
-      "type": "boolean"
-    },
-    "lastCommit": {
-      "description": "Run all tests affected by file changes in the last commit made. Behaves similarly to `--onlyChanged`.",
-      "type": "boolean"
-    },
-    "listTests": {
-      "default": false,
-      "description": "Lists all tests Jest will run given the arguments and exits. Most useful in a CI system together with `--findRelatedTests` to determine the tests Jest will run based on specific files",
-      "type": "boolean"
-    },
-    "logHeapUsage": {
-      "description": "Logs the heap usage after every test. Useful to debug memory leaks. Use together with `--runInBand` and `--expose-gc` in node.",
-      "type": "boolean"
-    },
-    "mapCoverage": {
-      "description": "Maps code coverage reports against original source code when transformers supply source maps.\n\nDEPRECATED",
-      "type": "boolean"
-    },
-    "maxWorkers": {
-      "alias": "w",
-      "description": "Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. (its usually best not to override this default)",
-      "type": ["integer", "string"]
-    },
-    "moduleDirectories": {
-      "description": "An array of directory names to be searched recursively up from the requiring module's location.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "moduleFileExtensions": {
-      "description": "An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for. ",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "moduleNameMapper": {
-      "description": "A JSON string with a map from regular expressions to module names that allow to stub out resources, like images or styles with a single module",
-      "type": "string"
-    },
-    "modulePathIgnorePatterns": {
-      "description": "An array of regexp pattern strings that are matched against all module paths before those paths are to be considered \"visible\" to the module loader.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "modulePaths": {
-      "description": "An alternative API to setting the NODE_PATH env variable, modulePaths is an array of absolute paths to additional locations to search when resolving modules.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "noStackTrace": {
-      "description": "Disables stack trace in test results output",
-      "type": "boolean"
-    },
-    "notify": {
-      "description": "Activates notifications for test results.",
-      "type": "boolean"
-    },
-    "notifyMode": {
-      "default": "failure-change",
-      "description": "Specifies when notifications will appear for test results.",
-      "type": "string"
-    },
-    "onlyChanged": {
-      "alias": "o",
-      "description": "Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment.",
-      "type": "boolean"
-    },
-    "onlyFailures": {
-      "alias": "f",
-      "description": "Run tests that failed in the previous execution.",
-      "type": "boolean"
-    },
-    "outputFile": {
-      "description": "Write test results to a file when the --json option is also specified.",
-      "type": "string"
-    },
-    "passWithNoTests": {
-      "default": false,
-      "description": "Will not fail if no tests are found (for example while using `--testPathPattern`.)",
-      "type": "boolean"
-    },
-    "preset": {
-      "description": "A preset that is used as a base for Jest's configuration.",
-      "type": "string"
-    },
-    "prettierPath": {
-      "default": "prettier",
-      "description": "The path to the \"prettier\" module used for inline snapshots.",
-      "type": "string"
-    },
-    "projects": {
-      "description": "A list of projects that use Jest to run all tests of all projects in a single instance of Jest.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "reporters": {
-      "description": "A list of custom reporters for the test suite.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "resetMocks": {
-      "description": "Automatically reset mock state between every test. Equivalent to calling jest.resetAllMocks() between each test.",
-      "type": "boolean"
-    },
-    "resetModules": {
-      "description": "If enabled, the module registry for every test file will be reset before running each individual test.",
-      "type": "boolean"
-    },
-    "resolver": {
-      "description": "A JSON string which allows the use of a custom resolver.",
-      "type": "string"
-    },
-    "restoreMocks": {
-      "description": "Automatically restore mock state and implementation between every test. Equivalent to calling jest.restoreAllMocks() between each test.",
-      "type": "boolean"
-    },
-    "rootDir": {
-      "description": "The root directory that Jest should scan for tests and modules within.",
-      "type": "string"
-    },
-    "roots": {
-      "description": "A list of paths to directories that Jest should use to search for files in.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "runInBand": {
-      "alias": "i",
-      "description": "Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare.",
-      "type": "boolean"
-    },
-    "runTestsByPath": {
-      "default": false,
-      "description": "Used when provided patterns are exact file paths. This avoids converting them into a regular expression and matching it against every single file.",
-      "type": "boolean"
-    },
-    "runner": {
-      "description": "Allows to use a custom runner instead of Jest's default test runner.",
-      "type": "string"
-    },
-    "setupFiles": {
-      "description": "The paths to modules that run some code to configure or set up the testing environment before each test. ",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "setupFilesAfterEnv": {
-      "description": "A list of paths to modules that run some code to configure or set up the testing framework before each test.",
-      "type": "string"
-    },
-    "showConfig": {
-      "description": "Print your jest config and then exits.",
-      "type": "boolean"
-    },
-    "silent": {
-      "description": "Prevent tests from printing messages through the console.",
-      "type": "boolean"
-    },
-    "skipFilter": {
-      "description": "Disables the filter provided by --filter. Useful for CI jobs, or local enforcement when fixing tests.",
-      "type": "boolean"
-    },
-    "snapshotSerializers": {
-      "description": "A list of paths to snapshot serializer modules Jest should use for snapshot testing.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "testEnvironment": {
-      "description": "Alias for --env",
-      "type": "string"
-    },
-    "testEnvironmentOptions": {
-      "description": "Test environment options that will be passed to the testEnvironment. The relevant options depend on the environment.",
-      "type": "string"
-    },
-    "testFailureExitCode": {
-      "description": "Exit code of `jest` command if the test run failed",
-      "type": "string"
-    },
-    "testLocationInResults": {
-      "default": false,
-      "description": "Add `location` information to the test results",
-      "type": "boolean"
-    },
-    "testMatch": {
-      "description": "The glob patterns Jest uses to detect test files.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "testNamePattern": {
-      "alias": "t",
-      "description": "Run only tests with a name that matches the regex pattern.",
-      "type": "string"
-    },
-    "testPathIgnorePatterns": {
-      "description": "An array of regexp pattern strings that are matched against all test paths before executing the test. If the test path matches any of the patterns, it will be skipped.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "testPathPattern": {
-      "description": "A regexp pattern string that is matched against all tests paths before executing the test.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "testRegex": {
-      "description": "A string or array of string regexp patterns that Jest uses to detect test files.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "testResultsProcessor": {
-      "description": "Allows the use of a custom results processor. This processor must be a node module that exports a function expecting as the first argument the result object.",
-      "type": "string"
-    },
-    "testRunner": {
-      "description": "Allows to specify a custom test runner. The default is  `jasmine2`. A path to a custom test runner can be provided: `<rootDir>/path/to/testRunner.js`.",
-      "type": "string"
-    },
-    "testURL": {
-      "description": "This option sets the URL for the jsdom environment.",
-      "type": "string"
-    },
-    "timers": {
-      "description": "Setting this value to fake allows the use of fake timers for functions such as setTimeout.",
-      "type": "string"
-    },
-    "transform": {
-      "description": "A JSON string which maps from regular expressions to paths to transformers.",
-      "type": "string"
-    },
-    "transformIgnorePatterns": {
-      "description": "An array of regexp pattern strings that are matched against all source file paths before transformation.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "unmockedModulePathPatterns": {
-      "description": "An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "updateSnapshot": {
-      "alias": "u",
-      "description": "Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern",
-      "type": "boolean"
-    },
-    "useStderr": {
-      "description": "Divert all output to stderr.",
-      "type": "boolean"
-    },
-    "verbose": {
-      "description": "Display individual test results with the test suite hierarchy.",
-      "type": "boolean"
-    },
-    "version": {
-      "alias": "v",
-      "description": "Print the version and exit",
-      "type": "boolean"
-    },
-    "watch": {
-      "description": "Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option.",
-      "type": "boolean"
-    },
-    "watchAll": {
-      "description": "Watch files for changes and rerun all tests. If you want to re-run only the tests related to the changed files, use the `--watch` option.",
-      "type": "boolean"
-    },
-    "watchPathIgnorePatterns": {
-      "description": "An array of regexp pattern strings that are matched against all paths before trigger test re-run in watch mode. If the test path matches any of the patterns, it will be skipped.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "watchman": {
-      "description": "Whether to use watchman for file crawling. Disable using --no-watchman.",
-      "type": "boolean"
+    "all":{
+      "description":"The opposite of `onlyChanged`. If `onlyChanged` is set by default, running jest with `--all` will force Jest to run all tests instead of running only tests related to changed files.",
+      "type":"boolean"
+    },
+    "automock":{
+      "description":"Automock all files by default.",
+      "type":"boolean"
+    },
+    "bail":{
+      "alias":"b",
+      "description":"Exit the test suite immediately after `n` number of failing tests.",
+      "type":"boolean"
+    },
+    "browser":{
+      "description":"Respect the \"browser\" field in package.json when resolving modules. Some packages export different versions based on whether they are operating in node.js or a browser.",
+      "type":"boolean"
+    },
+    "cache":{
+      "description":"Whether to use the transform cache. Disable the cache using --no-cache.",
+      "type":"boolean"
+    },
+    "cacheDirectory":{
+      "description":"The directory where Jest should store its cached  dependency information.",
+      "type":"string"
+    },
+    "changedFilesWithAncestor":{
+      "description":"Runs tests related to the current changes and the changes made in the last commit. Behaves similarly to `--onlyChanged`.",
+      "type":"boolean"
+    },
+    "changedSince":{
+      "description":"Runs tests related to the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.",
+      "nargs":1,
+      "type":"string"
+    },
+    "ci":{
+      "description":"Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested.",
+      "type":"boolean"
+    },
+    "clearCache":{
+      "description":"Clears the configured Jest cache directory and then exits. Default directory can be found by calling jest --showConfig",
+      "type":"boolean"
+    },
+    "clearMocks":{
+      "description":"Automatically clear mock calls and instances between every test. Equivalent to calling jest.clearAllMocks() between each test.",
+      "type":"boolean"
+    },
+    "collectCoverage":{
+      "description":"Alias for --coverage.",
+      "type":"boolean"
+    },
+    "collectCoverageFrom":{
+      "description":"A glob pattern relative to <rootDir> matching the files that coverage info needs to be collected from.",
+      "type":"string"
+    },
+    "collectCoverageOnlyFrom":{
+      "description":"Explicit list of paths coverage will be restricted to.",
+      "string":true,
+      "type":"array"
+    },
+    "color":{
+      "description":"Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors.",
+      "type":"boolean"
+    },
+    "colors":{
+      "description":"Alias for `--color`.",
+      "type":"boolean"
+    },
+    "config":{
+      "alias":"c",
+      "description":"The path to a jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project.This can also be a JSON encoded value which Jest will use as configuration.",
+      "type":"string"
+    },
+    "coverage":{
+      "description":"Indicates that test coverage information should be collected and reported in the output.",
+      "type":"boolean"
+    },
+    "coverageDirectory":{
+      "description":"The directory where Jest should output its coverage files.",
+      "type":"string"
+    },
+    "coveragePathIgnorePatterns":{
+      "description":"An array of regexp pattern strings that are matched against all file paths before executing the test. If the file pathmatches any of the patterns, coverage information will be skipped.",
+      "string":true,
+      "type":"array"
+    },
+    "coverageProvider":{
+      "choices":[
+        "babel",
+        "v8"
+      ],
+      "description":"Select between Babel and V8 to collect coverage"
+    },
+    "coverageReporters":{
+      "description":"A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter can be used.",
+      "string":true,
+      "type":"array"
+    },
+    "coverageThreshold":{
+      "description":"A JSON string with which will be used to configure minimum threshold enforcement for coverage results",
+      "type":"string"
+    },
+    "debug":{
+      "description":"Print debugging info about your jest config.",
+      "type":"boolean"
+    },
+    "detectLeaks":{
+      "description":"**EXPERIMENTAL**: Detect memory leaks in tests. After executing a test, it will try to garbage collect the global object used, and fail if it was leaked",
+      "type":"boolean"
+    },
+    "detectOpenHandles":{
+      "description":"Print out remaining open handles preventing Jest from exiting at the end of a test run. Implies `runInBand`.",
+      "type":"boolean"
+    },
+    "env":{
+      "description":"The test environment used for all tests. This can point to any file or node module. Examples: `jsdom`, `node` or `path/to/my-environment.js`",
+      "type":"string"
+    },
+    "errorOnDeprecated":{
+      "description":"Make calling deprecated APIs throw helpful error messages.",
+      "type":"boolean"
+    },
+    "expand":{
+      "alias":"e",
+      "description":"Use this flag to show full diffs instead of a patch.",
+      "type":"boolean"
+    },
+    "filter":{
+      "description":"Path to a module exporting a filtering function. This method receives a list of tests which can be manipulated to exclude tests from running. Especially useful when used in conjunction with a testing infrastructure to filter known broken tests.",
+      "type":"string"
+    },
+    "findRelatedTests":{
+      "description":"Find related tests for a list of source files that were passed in as arguments. Useful for pre-commit hook integration to run the minimal amount of tests necessary.",
+      "type":"boolean"
+    },
+    "forceExit":{
+      "description":"Force Jest to exit after all tests have completed running. This is useful when resources set up by test code cannot be adequately cleaned up.",
+      "type":"boolean"
+    },
+    "globalSetup":{
+      "description":"The path to a module that runs before All Tests.",
+      "type":"string"
+    },
+    "globalTeardown":{
+      "description":"The path to a module that runs after All Tests.",
+      "type":"string"
+    },
+    "globals":{
+      "description":"A JSON string with map of global variables that need to be available in all test environments.",
+      "type":"string"
+    },
+    "haste":{
+      "description":"A JSON string with map of variables for the haste module system",
+      "type":"string"
+    },
+    "init":{
+      "description":"Generate a basic configuration file",
+      "type":"boolean"
+    },
+    "injectGlobals":{
+      "description":"Should Jest inject global variables or not",
+      "type":"boolean"
+    },
+    "json":{
+      "description":"Prints the test results in JSON. This mode will send all other test output and user messages to stderr.",
+      "type":"boolean"
+    },
+    "lastCommit":{
+      "description":"Run all tests affected by file changes in the last commit made. Behaves similarly to `--onlyChanged`.",
+      "type":"boolean"
+    },
+    "listTests":{
+      "description":"Lists all tests Jest will run given the arguments and exits. Most useful in a CI system together with `--findRelatedTests` to determine the tests Jest will run based on specific files",
+      "type":"boolean"
+    },
+    "logHeapUsage":{
+      "description":"Logs the heap usage after every test. Useful to debug memory leaks. Use together with `--runInBand` and `--expose-gc` in node.",
+      "type":"boolean"
+    },
+    "maxConcurrency":{
+      "description":"Specifies the maximum number of tests that are allowed to runconcurrently. This only affects tests using `test.concurrent`.",
+      "type":"number"
+    },
+    "maxWorkers":{
+      "alias":"w",
+      "description":"Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. (its usually best not to override this default)",
+      "type":"string"
+    },
+    "moduleDirectories":{
+      "description":"An array of directory names to be searched recursively up from the requiring module's location.",
+      "string":true,
+      "type":"array"
+    },
+    "moduleFileExtensions":{
+      "description":"An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for. ",
+      "string":true,
+      "type":"array"
+    },
+    "moduleNameMapper":{
+      "description":"A JSON string with a map from regular expressions to module names or to arrays of module names that allow to stub out resources, like images or styles with a single module",
+      "type":"string"
+    },
+    "modulePathIgnorePatterns":{
+      "description":"An array of regexp pattern strings that are matched against all module paths before those paths are to be considered \"visible\" to the module loader.",
+      "string":true,
+      "type":"array"
+    },
+    "modulePaths":{
+      "description":"An alternative API to setting the NODE_PATH env variable, modulePaths is an array of absolute paths to additional locations to search when resolving modules.",
+      "string":true,
+      "type":"array"
+    },
+    "noStackTrace":{
+      "description":"Disables stack trace in test results output",
+      "type":"boolean"
+    },
+    "notify":{
+      "description":"Activates notifications for test results.",
+      "type":"boolean"
+    },
+    "notifyMode":{
+      "description":"Specifies when notifications will appear for test results.",
+      "type":"string"
+    },
+    "onlyChanged":{
+      "alias":"o",
+      "description":"Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment.",
+      "type":"boolean"
+    },
+    "onlyFailures":{
+      "alias":"f",
+      "description":"Run tests that failed in the previous execution.",
+      "type":"boolean"
+    },
+    "outputFile":{
+      "description":"Write test results to a file when the --json option is also specified.",
+      "type":"string"
+    },
+    "passWithNoTests":{
+      "description":"Will not fail if no tests are found (for example while using `--testPathPattern`.)",
+      "type":"boolean"
+    },
+    "preset":{
+      "description":"A preset that is used as a base for Jest's configuration.",
+      "type":"string"
+    },
+    "prettierPath":{
+      "description":"The path to the \"prettier\" module used for inline snapshots.",
+      "type":"string"
+    },
+    "projects":{
+      "description":"A list of projects that use Jest to run all tests of all projects in a single instance of Jest.",
+      "string":true,
+      "type":"array"
+    },
+    "reporters":{
+      "description":"A list of custom reporters for the test suite.",
+      "string":true,
+      "type":"array"
+    },
+    "resetMocks":{
+      "description":"Automatically reset mock state between every test. Equivalent to calling jest.resetAllMocks() between each test.",
+      "type":"boolean"
+    },
+    "resetModules":{
+      "description":"If enabled, the module registry for every test file will be reset before running each individual test.",
+      "type":"boolean"
+    },
+    "resolver":{
+      "description":"A JSON string which allows the use of a custom resolver.",
+      "type":"string"
+    },
+    "restoreMocks":{
+      "description":"Automatically restore mock state and implementation between every test. Equivalent to calling jest.restoreAllMocks() between each test.",
+      "type":"boolean"
+    },
+    "rootDir":{
+      "description":"The root directory that Jest should scan for tests and modules within.",
+      "type":"string"
+    },
+    "roots":{
+      "description":"A list of paths to directories that Jest should use to search for files in.",
+      "string":true,
+      "type":"array"
+    },
+    "runInBand":{
+      "alias":"i",
+      "description":"Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare.",
+      "type":"boolean"
+    },
+    "runTestsByPath":{
+      "description":"Used when provided patterns are exact file paths. This avoids converting them into a regular expression and matching it against every single file.",
+      "type":"boolean"
+    },
+    "runner":{
+      "description":"Allows to use a custom runner instead of Jest's default test runner.",
+      "type":"string"
+    },
+    "selectProjects":{
+      "description":"Run only the tests of the specified projects.Jest uses the attribute `displayName` in the configuration to identify each project.",
+      "string":true,
+      "type":"array"
+    },
+    "setupFiles":{
+      "description":"A list of paths to modules that run some code to configure or set up the testing environment before each test. ",
+      "string":true,
+      "type":"array"
+    },
+    "setupFilesAfterEnv":{
+      "description":"A list of paths to modules that run some code to configure or set up the testing framework before each test ",
+      "string":true,
+      "type":"array"
+    },
+    "showConfig":{
+      "description":"Print your jest config and then exits.",
+      "type":"boolean"
+    },
+    "silent":{
+      "description":"Prevent tests from printing messages through the console.",
+      "type":"boolean"
+    },
+    "skipFilter":{
+      "description":"Disables the filter provided by --filter. Useful for CI jobs, or local enforcement when fixing tests.",
+      "type":"boolean"
+    },
+    "snapshotSerializers":{
+      "description":"A list of paths to snapshot serializer modules Jest should use for snapshot testing.",
+      "string":true,
+      "type":"array"
+    },
+    "testEnvironment":{
+      "description":"Alias for --env",
+      "type":"string"
+    },
+    "testEnvironmentOptions":{
+      "description":"Test environment options that will be passed to the testEnvironment. The relevant options depend on the environment.",
+      "type":"string"
+    },
+    "testFailureExitCode":{
+      "description":"Exit code of `jest` command if the test run failed",
+      "type":"string"
+    },
+    "testLocationInResults":{
+      "description":"Add `location` information to the test results",
+      "type":"boolean"
+    },
+    "testMatch":{
+      "description":"The glob patterns Jest uses to detect test files.",
+      "string":true,
+      "type":"array"
+    },
+    "testNamePattern":{
+      "alias":"t",
+      "description":"Run only tests with a name that matches the regex pattern.",
+      "type":"string"
+    },
+    "testPathIgnorePatterns":{
+      "description":"An array of regexp pattern strings that are matched against all test paths before executing the test. If the test path matches any of the patterns, it will be skipped.",
+      "string":true,
+      "type":"array"
+    },
+    "testPathPattern":{
+      "description":"A regexp pattern string that is matched against all tests paths before executing the test.",
+      "string":true,
+      "type":"array"
+    },
+    "testRegex":{
+      "description":"A string or array of string regexp patterns that Jest uses to detect test files.",
+      "string":true,
+      "type":"array"
+    },
+    "testResultsProcessor":{
+      "description":"Allows the use of a custom results processor. This processor must be a node module that exports a function expecting as the first argument the result object.",
+      "type":"string"
+    },
+    "testRunner":{
+      "description":"Allows to specify a custom test runner. The default is `jest-circus/runner`. A path to a custom test runner can be provided: `<rootDir>/path/to/testRunner.js`.",
+      "type":"string"
+    },
+    "testSequencer":{
+      "description":"Allows to specify a custom test sequencer. The default is `@jest/test-sequencer`. A path to a custom test sequencer can be provided: `<rootDir>/path/to/testSequencer.js`",
+      "type":"string"
+    },
+    "testTimeout":{
+      "description":"This option sets the default timeouts of test cases.",
+      "type":"number"
+    },
+    "testURL":{
+      "description":"This option sets the URL for the jsdom environment.",
+      "type":"string"
+    },
+    "timers":{
+      "description":"Setting this value to fake allows the use of fake timers for functions such as setTimeout.",
+      "type":"string"
+    },
+    "transform":{
+      "description":"A JSON string which maps from regular expressions to paths to transformers.",
+      "type":"string"
+    },
+    "transformIgnorePatterns":{
+      "description":"An array of regexp pattern strings that are matched against all source file paths before transformation.",
+      "string":true,
+      "type":"array"
+    },
+    "unmockedModulePathPatterns":{
+      "description":"An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them.",
+      "string":true,
+      "type":"array"
+    },
+    "updateSnapshot":{
+      "alias":"u",
+      "description":"Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern",
+      "type":"boolean"
+    },
+    "useStderr":{
+      "description":"Divert all output to stderr.",
+      "type":"boolean"
+    },
+    "verbose":{
+      "description":"Display individual test results with the test suite hierarchy.",
+      "type":"boolean"
+    },
+    "version":{
+      "alias":"v",
+      "description":"Print the version and exit",
+      "type":"boolean"
+    },
+    "watch":{
+      "description":"Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option.",
+      "type":"boolean"
+    },
+    "watchAll":{
+      "description":"Watch files for changes and rerun all tests. If you want to re-run only the tests related to the changed files, use the `--watch` option.",
+      "type":"boolean"
+    },
+    "watchPathIgnorePatterns":{
+      "description":"An array of regexp pattern strings that are matched against all paths before trigger test re-run in watch mode. If the test path matches any of the patterns, it will be skipped.",
+      "string":true,
+      "type":"array"
+    },
+    "watchman":{
+      "description":"Whether to use watchman for file crawling. Disable using --no-watchman.",
+      "type":"boolean"
     },
     "tsConfig": {
       "description": "The path to the TypeScript configuration file.",


### PR DESCRIPTION


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Some Jest CLI options are missing from the builder schema

## What is the new behavior?

The schema is aligned to the latest Jest [schema](https://github.com/facebook/jest/blob/master/packages/jest-cli/src/cli/args.ts) 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
