### PR TITLE
docs: update required jest version to 27

### DIFF
--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -18,7 +18,7 @@ The builder comes to provide zero configuration setup for Jest while keeping the
 ## Prerequisites
 
 - [Angular CLI 12](https://www.npmjs.com/package/@angular/cli)
-- [Jest 26](https://www.npmjs.com/package/jest)
+- [Jest 27](https://www.npmjs.com/package/jest)
 
 ## Installation
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

The documentation states that jest 26 is required. However, the package.json requires >= 27
Also, `ng update @angular-builders/jest` updates jest to 27 as well.

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
