### PR TITLE
fix(custom-webpack): warn about multiple tsconfigs for custom config

### DIFF
--- a/packages/custom-webpack/src/custom-webpack-builder.spec.ts
+++ b/packages/custom-webpack/src/custom-webpack-builder.spec.ts
@@ -71,7 +71,8 @@ describe('CustomWebpackBuilder', () => {
       null,
       baseWebpackConfig,
       {},
-      targetOptions
+      targetOptions,
+      {} as any
     );
 
     expect(mergedConfig).toEqual(baseWebpackConfig);
@@ -85,7 +86,8 @@ describe('CustomWebpackBuilder', () => {
       {},
       baseWebpackConfig,
       {},
-      targetOptions
+      targetOptions,
+      {} as any
     );
 
     try {
@@ -110,7 +112,8 @@ describe('CustomWebpackBuilder', () => {
       { path: fileName },
       baseWebpackConfig,
       {},
-      targetOptions
+      targetOptions,
+      {} as any
     );
 
     try {
@@ -135,7 +138,8 @@ describe('CustomWebpackBuilder', () => {
       { mergeRules },
       baseWebpackConfig,
       {},
-      targetOptions
+      targetOptions,
+      {} as any
     );
 
     try {
@@ -159,7 +163,8 @@ describe('CustomWebpackBuilder', () => {
       { replaceDuplicatePlugins: true },
       baseWebpackConfig,
       {},
-      targetOptions
+      targetOptions,
+      {} as any
     );
 
     try {
@@ -177,7 +182,8 @@ describe('CustomWebpackBuilder', () => {
       {},
       baseWebpackConfig,
       buildOptions,
-      targetOptions
+      targetOptions,
+      {} as any
     );
     expect(spy).toHaveBeenCalledWith(baseWebpackConfig, buildOptions, targetOptions);
   });
@@ -190,7 +196,8 @@ describe('CustomWebpackBuilder', () => {
       {},
       baseWebpackConfig,
       {},
-      targetOptions
+      targetOptions,
+      {} as any
     );
 
     expect(mergedConfig).toEqual(customWebpackFunctionObj);
@@ -214,7 +221,8 @@ describe('CustomWebpackBuilder', () => {
       {},
       baseWebpackConfig,
       {},
-      targetOptions
+      targetOptions,
+      {} as any
     );
 
     expect(result).toBeInstanceOf(Promise);
@@ -243,7 +251,8 @@ describe('CustomWebpackBuilder', () => {
       {},
       baseWebpackConfig,
       {},
-      targetOptions
+      targetOptions,
+      {} as any
     );
 
     expect(result).toBeInstanceOf(Promise);

--- a/packages/custom-webpack/src/custom-webpack-builder.ts
+++ b/packages/custom-webpack/src/custom-webpack-builder.ts
@@ -1,4 +1,4 @@
-import { getSystemPath, Path } from '@angular-devkit/core';
+import { getSystemPath, Path, logging } from '@angular-devkit/core';
 import { Configuration } from 'webpack';
 
 import { mergeConfigs } from './webpack-config-merger';
@@ -29,7 +29,8 @@ export class CustomWebpackBuilder {
     config: CustomWebpackBuilderConfig,
     baseWebpackConfig: Configuration,
     buildOptions: any,
-    targetOptions: TargetOptions
+    targetOptions: TargetOptions,
+    logger: logging.LoggerApi
   ): Promise<Configuration> {
     if (!config) {
       return baseWebpackConfig;
@@ -38,7 +39,7 @@ export class CustomWebpackBuilder {
     const webpackConfigPath = config.path || defaultWebpackConfigPath;
     const path = `${getSystemPath(root)}/${webpackConfigPath}`;
     const tsConfig = `${getSystemPath(root)}/${buildOptions.tsConfig}`;
-    const configOrFactoryOrPromise = resolveCustomWebpackConfig(path, tsConfig);
+    const configOrFactoryOrPromise = resolveCustomWebpackConfig(path, tsConfig, logger);
 
     if (typeof configOrFactoryOrPromise === 'function') {
       // That exported function can be synchronous either
@@ -64,8 +65,12 @@ export class CustomWebpackBuilder {
   }
 }
 
-function resolveCustomWebpackConfig(path: string, tsConfig: string): CustomWebpackConfig {
-  tsNodeRegister(path, tsConfig);
+function resolveCustomWebpackConfig(
+  path: string,
+  tsConfig: string,
+  logger: logging.LoggerApi
+): CustomWebpackConfig {
+  tsNodeRegister(path, tsConfig, logger);
 
   const customWebpackConfig = require(path);
   // If the user provides a configuration in TS file

--- a/packages/custom-webpack/src/transform-factories.spec.ts
+++ b/packages/custom-webpack/src/transform-factories.spec.ts
@@ -9,11 +9,15 @@ jest.spyOn(utils, 'tsNodeRegister');
 
 import { getTransforms } from './transform-factories';
 
+const logger = { warn: jest.fn(msg => console.log(msg)) };
+
 describe('getTransforms', () => {
   beforeEach(() => {
     jest.resetModules();
+    jest.clearAllMocks();
   });
-  it('should call ts-node register once with typescript index-html-transform & custom-webpack-config', () => {
+
+  it('should call ts-node register once with typescript index-html-transform & custom-webpack-config AND warn if called with a different config', () => {
     jest.mock('test/index-transform.test.ts', () => jest.fn(), { virtual: true });
     jest.mock('test/webpack.test.config.ts', () => jest.fn(), { virtual: true });
     const tsNode = require('ts-node') as jest.Mocked<typeof import('ts-node')>;
@@ -26,18 +30,35 @@ describe('getTransforms', () => {
         indexTransform: 'index-transform.test.ts',
         tsConfig: 'tsconfig.test.json',
       },
-      { workspaceRoot: './test' } as any
+      { workspaceRoot: './test', logger } as any
     );
     transforms.webpackConfiguration({});
 
     expect(utils.tsNodeRegister).toHaveBeenCalledWith(
       'test/webpack.test.config.ts',
-      'test/tsconfig.test.json'
+      'test/tsconfig.test.json',
+      logger
     );
     expect(utils.tsNodeRegister).toHaveBeenCalledWith(
       'index-transform.test.ts',
-      'test/tsconfig.test.json'
+      'test/tsconfig.test.json',
+      logger
     );
     expect(tsNode.register).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    const transforms2 = getTransforms(
+      {
+        customWebpackConfig: {
+          path: 'webpack.test.config.ts',
+        },
+        indexTransform: '',
+        tsConfig: 'tsconfig.test2.json',
+      },
+      { workspaceRoot: './test', logger } as any
+    );
+    transforms2.webpackConfiguration({});
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/custom-webpack/src/transform-factories.ts
+++ b/packages/custom-webpack/src/transform-factories.ts
@@ -11,23 +11,24 @@ export const customWebpackConfigTransformFactory: (
   options: CustomWebpackSchema,
   context: BuilderContext
 ) => ExecutionTransformer<Configuration> =
-  (options, { workspaceRoot, target }) =>
+  (options, { workspaceRoot, target, logger }) =>
   browserWebpackConfig => {
     return CustomWebpackBuilder.buildWebpackConfig(
       normalize(workspaceRoot),
       options.customWebpackConfig,
       browserWebpackConfig,
       options,
-      target
+      target,
+      logger
     );
   };
 
 export const indexHtmlTransformFactory: (
   options: CustomWebpackSchema,
   context: BuilderContext
-) => IndexHtmlTransform = ({ indexTransform, tsConfig }, { workspaceRoot, target }) => {
+) => IndexHtmlTransform = ({ indexTransform, tsConfig }, { workspaceRoot, target, logger }) => {
   if (!indexTransform) return null;
-  tsNodeRegister(indexTransform, `${getSystemPath(normalize(workspaceRoot))}/${tsConfig}`);
+  tsNodeRegister(indexTransform, `${getSystemPath(normalize(workspaceRoot))}/${tsConfig}`, logger);
   const indexModule = require(`${getSystemPath(normalize(workspaceRoot))}/${indexTransform}`);
   const transform = indexModule.default || indexModule;
   return async (indexHtml: string) => transform(target, indexHtml);

--- a/packages/custom-webpack/src/utils.ts
+++ b/packages/custom-webpack/src/utils.ts
@@ -1,14 +1,20 @@
+import { logging } from '@angular-devkit/core';
+
 const _tsNodeRegister = (() => {
-  let lastTsConfig: string | null | undefined;
-  return (tsConfig?: string) => {
+  let lastTsConfig: string | undefined;
+  return (tsConfig: string, logger: logging.LoggerApi) => {
     // Check if the function was previously called with the same tsconfig
-    if (typeof lastTsConfig !== 'undefined' && (tsConfig ?? null) !== lastTsConfig) {
-      throw new Error('Called with multiple tsconfigs.');
+    if (lastTsConfig && lastTsConfig !== tsConfig) {
+      logger.warn(`Trying to register ts-node again with a different tsconfig - skipping the registration.
+                   tsconfig 1: ${lastTsConfig}
+                   tsconfig 2: ${tsConfig}`);
     }
+
     if (lastTsConfig) {
       return;
     }
-    lastTsConfig = tsConfig ?? null;
+
+    lastTsConfig = tsConfig;
 
     // Register ts-node
     require('ts-node').register({
@@ -35,9 +41,9 @@ const _tsNodeRegister = (() => {
  * @param file: file name or file directory are allowed
  * @todo tsNodeRegistration: require ts-node if file extension is TypeScript
  */
-export function tsNodeRegister(file: string = '', tsConfig?: string) {
+export function tsNodeRegister(file: string = '', tsConfig: string, logger: logging.LoggerApi) {
   if (file && file.endsWith('.ts')) {
     // Register TS compiler lazily
-    _tsNodeRegister(tsConfig);
+    _tsNodeRegister(tsConfig, logger);
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Closes #1037 

## What is the new behavior?

Multiple `ts-node` registration attempts result in a warning, only first is really registered.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Initially issue was introduced with PR #1035. The original PR aimed to solve `ts-node` double registration with the same tsconfig and the base assumption was that it would never be called with two different tsconfigs.  
That assumption, however, turned to be wrong - in #1037 we see that the usage of `@nguniversal/builders` results in `browser` and `server` builders run in the same process, which effectively throws an exception.  
This PR fixes this use case and presents a warning instead of exception.  

@GerkinDev FYI. 


