### PR TITLE
ci: cache Yarn and Cypress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,12 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: actions/cache@v2
-        id: node-modules
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: |
-            node_modules
-            **/node_modules
-          key: ${{ runner.os }}-node-modules
-          restore-keys: ${{ runner.os }}-node-modules
+          path: ~/.cache # Default cache directory for both Yarn and Cypress
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`node_modules` directories are cached .  
This bypasses more intelligent caching packaged with `npm` or `yarn`, and can cause issues with Cypress not downloading the Cypress binary on `yarn install`.

## What is the new behavior?

`~/.cache` directory is cached, it's a default directory for both Cyrpess and Yarn.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
