### PR TITLE
chore: use resolutions for @cypress/schematic only

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     ]
   },
   "resolutions": {
-    "@angular-devkit/architect": ">=0.1300.0 < 0.1400.0",
-    "@angular-devkit/core": "^13",
-    "@angular-devkit/schematics": "^13",
-    "@schematics/angular": "^13"
+    "**/@cypress/schematic/@angular-devkit/architect": ">=0.1300.0 < 0.1400.0",
+    "**/@cypress/schematic/@angular-devkit/core": "^13",
+    "**/@cypress/schematic/@angular-devkit/schematics": "^13",
+    "**/@cypress/schematic/@schematics/angular": "^13"
   },
   "author": "Evgeny Barabanov",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,7 +98,7 @@
     "@angular-devkit/architect" "0.1301.3"
     rxjs "6.6.7"
 
-"@angular-devkit/core@13.1.3", "@angular-devkit/core@^12.2.10", "@angular-devkit/core@^13", "@angular-devkit/core@^13.0.0":
+"@angular-devkit/core@13.1.3", "@angular-devkit/core@^13.0.0":
   version "13.1.3"
   resolved "https://registry.npmjs.org/@angular-devkit/core/-/core-13.1.3.tgz#d1f8a6b4ad4326732a160a7549fccca1369fd108"
   integrity sha512-o14jGDk4h14dVYYQafOn+2rq9CDmDMbDV6logqKYCLzTDRlK8gccDnqJM/QKAlfWCzbllZqcHDmg6FyoRLO9RQ==
@@ -110,12 +110,35 @@
     rxjs "6.6.7"
     source-map "0.7.3"
 
-"@angular-devkit/schematics@13.1.3", "@angular-devkit/schematics@^12.2.10", "@angular-devkit/schematics@^13":
+"@angular-devkit/core@13.1.4", "@angular-devkit/core@^12.2.10", "@angular-devkit/core@^13":
+  version "13.1.4"
+  resolved "https://registry.npmjs.org/@angular-devkit/core/-/core-13.1.4.tgz#b5b6ddd674ae351f83beff2e4a0d702096bdfd47"
+  integrity sha512-225Gjy4iVxh5Jo9njJnaG75M/Dt95UW+dEPCGWKV5E/++7UUlXlo9sNWq8x2vJm2nhtsPkpnXNOt4pW1mIDwqQ==
+  dependencies:
+    ajv "8.8.2"
+    ajv-formats "2.1.1"
+    fast-json-stable-stringify "2.1.0"
+    magic-string "0.25.7"
+    rxjs "6.6.7"
+    source-map "0.7.3"
+
+"@angular-devkit/schematics@13.1.3":
   version "13.1.3"
   resolved "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-13.1.3.tgz#2328f9cf63d6f556392d96b73af794fc52bfc87f"
   integrity sha512-TvjThB/pFXNFM0j0WX5yg0L2/3xNsqawQuWhkDJ05MBDEnSxbgv5hmOzNL8SNIEMgP0VbSTHtSg5kZvmNiH7vg==
   dependencies:
     "@angular-devkit/core" "13.1.3"
+    jsonc-parser "3.0.0"
+    magic-string "0.25.7"
+    ora "5.4.1"
+    rxjs "6.6.7"
+
+"@angular-devkit/schematics@13.1.4", "@angular-devkit/schematics@^12.2.10", "@angular-devkit/schematics@^13":
+  version "13.1.4"
+  resolved "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-13.1.4.tgz#e8ed817887aa51268dec27d8d6188e2f3f10742a"
+  integrity sha512-yBa7IeC4cLZ7s137NAQD+sMB5c6SI6UJ6xYxl6J/CvV2RLGOZZA93i4GuRALi5s82eLi1fH+HEL/gvf3JQynzQ==
+  dependencies:
+    "@angular-devkit/core" "13.1.4"
     jsonc-parser "3.0.0"
     magic-string "0.25.7"
     ora "5.4.1"
@@ -2588,13 +2611,22 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@schematics/angular@13.1.3", "@schematics/angular@^12.2.10", "@schematics/angular@^13":
+"@schematics/angular@13.1.3":
   version "13.1.3"
   resolved "https://registry.npmjs.org/@schematics/angular/-/angular-13.1.3.tgz#c763cdf1a2e0784d5263c23b581bfeb4a4a2f12e"
   integrity sha512-IixVWAEtN97N74PCxg3T03Ar/ECjGyJBWKAjKTTCrgNSWhm2mKgIc4RyI6cVCnltfJWIo48fcFhlOx/elShaCg==
   dependencies:
     "@angular-devkit/core" "13.1.3"
     "@angular-devkit/schematics" "13.1.3"
+    jsonc-parser "3.0.0"
+
+"@schematics/angular@^12.2.10", "@schematics/angular@^13":
+  version "13.1.4"
+  resolved "https://registry.npmjs.org/@schematics/angular/-/angular-13.1.4.tgz#8b8c9ad40403c485bae9adeb51649711651189d2"
+  integrity sha512-P1YsHn1LLAmdpB9X2TBuUgrvEW/KaoBbHr8ifYO8/uQEXyeiIF+So8h/dnegkYkdsr3OwQ2X/j3UF6/+HS0odg==
+  dependencies:
+    "@angular-devkit/core" "13.1.4"
+    "@angular-devkit/schematics" "13.1.4"
     jsonc-parser "3.0.0"
 
 "@sinonjs/commons@^1.7.0":


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Yarn `resolutions` are used for all the packages 

## What is the new behavior?

Yarn `resolutions` are used just for the packages that need it (`@cypress/schematic`)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

