### PR TITLE
ci(renovate): run yarn-deduplicate on renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   ],
   "prHourlyLimit": 3,
   "updateInternalDeps": true,
+  "postUpdateOptions": ["yarnDedupeFewer"],
   "packageRules": [
     {
       "matchPaths": ["packages/**"],


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Sometimes (primarily on Angular CLI deps updates) the `yarn.lock` becomes bloated and causes the monorepo to contain multiple Angular versions, although according to the version range overlap there should be only one.

## What is the new behavior?

`yarn-deduplicate` is run after each dependency upgrade, thus minimizing the amount of different versions in monorepo

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```


