### PR TITLE
fix(jest): set path to tsconfig correctly

### DIFF
--- a/examples/jest/multiple-apps/tsconfig.spec.json
+++ b/examples/jest/multiple-apps/tsconfig.spec.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "../../out-tsc/spec"
-  },
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
-}

--- a/packages/jest/src/default-config.resolver.spec.ts
+++ b/packages/jest/src/default-config.resolver.spec.ts
@@ -10,7 +10,7 @@ describe('Resolve project default configuration', () => {
   it('Should resolve tsconfig relatively to project root', () => {
     const config = defaultConfigResolver.resolveForProject(normalize('/some/cool/directory'));
     expect(config.transform[defaultConfigResolver.tsJestTransformRegExp]).toEqual([
-      'ts-jest',
+      'jest-preset-angular',
       {
         tsconfig: getSystemPath(normalize(`/some/cool/directory/${tsConfigName}`)),
       },
@@ -23,7 +23,7 @@ describe('Resolve project default configuration', () => {
     });
     const config = defaultConfigResolver.resolveForProject(normalize('/some/cool/project'));
     expect(config.transform[defaultConfigResolver.tsJestTransformRegExp]).toEqual([
-      'ts-jest',
+      'jest-preset-angular',
       {
         tsconfig: getSystemPath(normalize(`/some/cool/project/ts-configs/tsconfig.spec.json`)),
       },

--- a/packages/jest/src/default-config.resolver.spec.ts
+++ b/packages/jest/src/default-config.resolver.spec.ts
@@ -12,6 +12,7 @@ describe('Resolve project default configuration', () => {
     expect(config.transform[defaultConfigResolver.tsJestTransformRegExp]).toEqual([
       'jest-preset-angular',
       {
+        stringifyContentPathRegex: '\\.(html|svg)$',
         tsconfig: getSystemPath(normalize(`/some/cool/directory/${tsConfigName}`)),
       },
     ]);
@@ -25,6 +26,7 @@ describe('Resolve project default configuration', () => {
     expect(config.transform[defaultConfigResolver.tsJestTransformRegExp]).toEqual([
       'jest-preset-angular',
       {
+        stringifyContentPathRegex: '\\.(html|svg)$',
         tsconfig: getSystemPath(normalize(`/some/cool/project/ts-configs/tsconfig.spec.json`)),
       },
     ]);

--- a/packages/jest/src/default-config.resolver.ts
+++ b/packages/jest/src/default-config.resolver.ts
@@ -1,5 +1,6 @@
 import { pick } from 'lodash';
 import { getSystemPath, normalize, Path } from '@angular-devkit/core';
+import { defaultTransformerOptions } from 'jest-preset-angular';
 
 import { JestConfig } from './types';
 import { getTsConfigPath } from './utils';
@@ -22,7 +23,7 @@ const getMockFiles = (enabledMocks: string[] = []): string[] =>
 
 export class DefaultConfigResolver {
   // Exposed publicly for testing purposes.
-  readonly tsJestTransformRegExp = '^.+\\.tsx?$';
+  readonly tsJestTransformRegExp = '^.+\\.(ts|js|mjs|html|svg)$';
 
   constructor(private options: JestBuilderSchema) {}
 
@@ -39,8 +40,9 @@ export class DefaultConfigResolver {
       testMatch: [`${getSystemPath(projectRoot)}${testPattern}`],
       transform: {
         [this.tsJestTransformRegExp]: [
-          'ts-jest',
+          'jest-preset-angular',
           {
+            ...defaultTransformerOptions,
             // Join with the default `tsConfigName` if the `tsConfig` option is not provided
             tsconfig: getTsConfigPath(projectRoot, this.options),
           },

--- a/packages/jest/src/default-config.resolver.ts
+++ b/packages/jest/src/default-config.resolver.ts
@@ -1,6 +1,5 @@
 import { pick } from 'lodash';
 import { getSystemPath, normalize, Path } from '@angular-devkit/core';
-import { defaultTransformerOptions } from 'jest-preset-angular';
 
 import { JestConfig } from './types';
 import { getTsConfigPath } from './utils';
@@ -42,7 +41,8 @@ export class DefaultConfigResolver {
         [this.tsJestTransformRegExp]: [
           'jest-preset-angular',
           {
-            ...defaultTransformerOptions,
+            // see: jest-preset-angular defaultTransformerOptions https://github.com/thymikee/jest-preset-angular/blob/main/src/presets/index.ts#L11
+            stringifyContentPathRegex: '\\.(html|svg)$',
             // Join with the default `tsConfigName` if the `tsConfig` option is not provided
             tsconfig: getTsConfigPath(projectRoot, this.options),
           },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
- [x] Bugfix

## What is the current behavior?

Option `tsConfig` in angular.json is ignored. `tsconfig.spec.json` [seems to be loaded from the CWD](https://github.com/just-jeb/angular-builders/issues/1408#issuecomment-1609794674) instead of the project root.

Issue Number: #1408 

## What is the new behavior?

## Does this PR introduce a breaking change?

Eventually yes, if suddenly the path to tsconfig is configured correctly.

## Other information
Followed the docs of `jest-preset-angular` to override/extend the transform config.
https://thymikee.github.io/jest-preset-angular/docs/getting-started/presets/#advanced

Tested it locally by building and copying over the dist folder to node_modules/@angular-builders/jest.