### PR TITLE
fix(common): update TS module resolution flow

### DIFF
--- a/examples/custom-webpack/sanity-app-esm/custom-webpack.config.ts
+++ b/examples/custom-webpack/sanity-app-esm/custom-webpack.config.ts
@@ -1,7 +1,14 @@
 import type { Configuration } from 'webpack';
 
+import { WebpackEsmPlugin } from 'webpack-esm-plugin';
+
 export default async (cfg: Configuration) => {
   const { default: configFromEsm } = await import('./custom-webpack.config.js');
+
+  // This is used to ensure we fixed the following issue:
+  // https://github.com/just-jeb/angular-builders/issues/1213
+  cfg.plugins!.push(new WebpackEsmPlugin());
+
   // Do some stuff with config and configFromEsm
   return { ...cfg, ...configFromEsm };
 };

--- a/examples/custom-webpack/sanity-app-esm/package.json
+++ b/examples/custom-webpack/sanity-app-esm/package.json
@@ -44,6 +44,7 @@
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.2.0",
     "puppeteer": "24.43.1",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "webpack-esm-plugin": "file:./webpack-esm-plugin"
   }
 }

--- a/examples/custom-webpack/sanity-app-esm/webpack-esm-plugin/package.json
+++ b/examples/custom-webpack/sanity-app-esm/webpack-esm-plugin/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "webpack-esm-plugin",
+  "version": "0.0.1",
+  "module": "./webpack-esm-plugin.mjs",
+  "typings": "./webpack-esm-plugin.d.ts",
+  "exports": {
+    "./package.json": {
+      "default": "./package.json"
+    },
+    ".": {
+      "types": "./webpack-esm-plugin.d.ts",
+      "node": "./webpack-esm-plugin.mjs",
+      "default": "./webpack-esm-plugin.mjs"
+    }
+  },
+  "sideEffects": false
+}

--- a/examples/custom-webpack/sanity-app-esm/webpack-esm-plugin/package.json
+++ b/examples/custom-webpack/sanity-app-esm/webpack-esm-plugin/package.json
@@ -9,6 +9,7 @@
     },
     ".": {
       "types": "./webpack-esm-plugin.d.ts",
+      "require": "./webpack-esm-plugin.cjs",
       "node": "./webpack-esm-plugin.mjs",
       "default": "./webpack-esm-plugin.mjs"
     }

--- a/examples/custom-webpack/sanity-app-esm/webpack-esm-plugin/webpack-esm-plugin.cjs
+++ b/examples/custom-webpack/sanity-app-esm/webpack-esm-plugin/webpack-esm-plugin.cjs
@@ -1,0 +1,7 @@
+'use strict';
+class WebpackEsmPlugin {
+  apply(compiler) {
+    console.error('hello from the WebpackEsmPlugin');
+  }
+}
+module.exports = { WebpackEsmPlugin };

--- a/examples/custom-webpack/sanity-app-esm/webpack-esm-plugin/webpack-esm-plugin.d.ts
+++ b/examples/custom-webpack/sanity-app-esm/webpack-esm-plugin/webpack-esm-plugin.d.ts
@@ -1,0 +1,5 @@
+import * as webpack from 'webpack';
+
+export declare class WebpackEsmPlugin {
+  apply(compiler: webpack.Compiler): void;
+}

--- a/examples/custom-webpack/sanity-app-esm/webpack-esm-plugin/webpack-esm-plugin.mjs
+++ b/examples/custom-webpack/sanity-app-esm/webpack-esm-plugin/webpack-esm-plugin.mjs
@@ -1,0 +1,7 @@
+class WebpackEsmPlugin {
+  apply(compiler) {
+    console.error('hello from the WebpackEsmPlugin');
+  }
+}
+
+export { WebpackEsmPlugin };

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,7 +24,6 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@angular-devkit/core": "^21.0.0",
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^4.2.0"
   },

--- a/packages/common/src/load-module.spec.ts
+++ b/packages/common/src/load-module.spec.ts
@@ -1,0 +1,27 @@
+import * as path from 'node:path';
+
+import { loadModule } from './load-module';
+
+const tsConfig = path.resolve(__dirname, '../tsconfig.json');
+const fixturesDir = path.resolve(__dirname, '../tests/fixtures');
+
+describe('loadModule', () => {
+  it('loads two TypeScript fixtures concurrently without losing ts-node registration', async () => {
+    // ts-node is registered+unregistered around each .ts load. Two parallel
+    // loads must each see a working register-require-unregister window, with
+    // neither call killing the other's compilation. (See PR #1659.)
+    const [a, b] = await Promise.all([
+      loadModule<{ name: string; value: number }>(
+        path.join(fixturesDir, 'concurrent-a.ts'),
+        tsConfig
+      ),
+      loadModule<{ name: string; value: number }>(
+        path.join(fixturesDir, 'concurrent-b.ts'),
+        tsConfig
+      ),
+    ]);
+
+    expect(a).toEqual({ name: 'concurrent-a', value: 1 });
+    expect(b).toEqual({ name: 'concurrent-b', value: 2 });
+  });
+});

--- a/packages/common/src/load-module.spec.ts
+++ b/packages/common/src/load-module.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { loadModule } from './load-module';
 
 const tsConfig = path.resolve(__dirname, '../tsconfig.json');
+const tsConfigBundler = path.resolve(__dirname, '../tests/fixtures/tsconfig.bundler.json');
 const fixturesDir = path.resolve(__dirname, '../tests/fixtures');
 
 describe('loadModule', () => {
@@ -23,5 +24,35 @@ describe('loadModule', () => {
 
     expect(a).toEqual({ name: 'concurrent-a', value: 1 });
     expect(b).toEqual({ name: 'concurrent-b', value: 2 });
+  });
+
+  it('loads a TypeScript fixture when the tsconfig specifies moduleResolution:bundler (regression for #1197, #1213)', async () => {
+    // Before the fix, ts-node was registered with module:CommonJS while the user tsconfig
+    // specified moduleResolution:bundler, causing TS5095/TS5110 errors. The fix adds a
+    // moduleResolution:node override in ts-node compiler options, which is safe under
+    // transpileOnly:true.
+    const result = await loadModule<{ name: string; value: number }>(
+      path.join(fixturesDir, 'simple.ts'),
+      tsConfigBundler
+    );
+
+    expect(result).toEqual({ name: 'simple', value: 42 });
+  });
+
+  it('loads two TypeScript fixtures with different tsconfigs sequentially without ts-node registration bleeding', async () => {
+    // The original bug (#1197): the second loadModule call with a different tsconfig
+    // would be silently skipped (first registration wins, process-global). With the
+    // per-load register+unregister model, each call uses its own tsconfig.
+    const resultFromBundlerConfig = await loadModule<{ name: string; value: number }>(
+      path.join(fixturesDir, 'simple.ts'),
+      tsConfigBundler
+    );
+    const resultFromDefaultConfig = await loadModule<{ name: string; value: number }>(
+      path.join(fixturesDir, 'concurrent-a.ts'),
+      tsConfig
+    );
+
+    expect(resultFromBundlerConfig).toEqual({ name: 'simple', value: 42 });
+    expect(resultFromDefaultConfig).toEqual({ name: 'concurrent-a', value: 1 });
   });
 });

--- a/packages/common/src/load-module.ts
+++ b/packages/common/src/load-module.ts
@@ -1,100 +1,27 @@
 import * as path from 'node:path';
 import * as url from 'node:url';
-import type { logging } from '@angular-devkit/core';
 
-const _tsNodeRegister = (() => {
-  let lastTsConfig: string | undefined;
-  return (tsConfig: string, logger: logging.LoggerApi) => {
-    // Check if the function was previously called with the same tsconfig
-    if (lastTsConfig && lastTsConfig !== tsConfig) {
-      logger.warn(`Trying to register ts-node again with a different tsconfig - skipping the registration.
-                   tsconfig 1: ${lastTsConfig}
-                   tsconfig 2: ${tsConfig}`);
-    }
-
-    if (lastTsConfig) {
-      return;
-    }
-
-    lastTsConfig = tsConfig;
-
-    loadTsNode().register({
-      project: tsConfig,
-      compilerOptions: {
-        module: 'CommonJS',
-        // We deliberately do NOT override moduleResolution here.
-        // The user's tsconfig moduleResolution setting (node, bundler, node16, etc.) is preserved.
-        // TypeScript allows moduleResolution:bundler with module:CommonJS, so type checking
-        // works correctly for all moduleResolution values — including 'bundler', which supports
-        // subpath package exports (e.g. '@angular/core/primitives/di').
-        // Overriding moduleResolution to 'node' (as was done previously) was the root cause of
-        // issue https://github.com/just-jeb/angular-builders/issues/2025: it prevented TypeScript
-        // from resolving subpath exports, causing TS2307 errors at build time.
-        types: [
-          'node', // NOTE: `node` is added so user configs can use Node.js globals (process, __dirname, etc.)
-        ],
-      },
-    });
-
-    const tsConfigPaths = loadTsConfigPaths();
-    const result = tsConfigPaths.loadConfig(tsConfig);
-    // The `loadConfig` returns a `ConfigLoaderResult` which must be guarded with
-    // the `resultType` check.
-    if (result.resultType === 'success') {
-      const { absoluteBaseUrl: baseUrl, paths } = result;
-      if (baseUrl && paths) {
-        tsConfigPaths.register({ baseUrl, paths });
-      }
-    }
-  };
-})();
-
-/**
- * check for TS node registration
- * @param file: file name or file directory are allowed
- */
-function tsNodeRegister(file: string = '', tsConfig: string, logger: logging.LoggerApi) {
-  if (file?.endsWith('.ts')) {
-    // Register TS compiler lazily
-    _tsNodeRegister(tsConfig, logger);
-  }
-}
-
-/**
- * This uses a dynamic import to load a module which may be ESM.
- * CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript
- * will currently, unconditionally downlevel dynamic import into a require call.
- * require calls cannot load ESM code and will result in a runtime error. To workaround
- * this, a Function constructor is used to prevent TypeScript from changing the dynamic import.
- * Once TypeScript provides support for keeping the dynamic import this workaround can
- * be dropped.
- *
- * @param modulePath The path of the module to load.
- * @returns A Promise that resolves to the dynamically imported module.
- */
-function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
-  return new Function('modulePath', `return import(modulePath);`)(modulePath) as Promise<T>;
-}
+import { registerTsProject } from './register-ts-project';
 
 /**
  * Loads CJS and ESM modules based on extension
  */
-export async function loadModule<T>(
-  modulePath: string,
-  tsConfig: string,
-  logger: logging.LoggerApi
-): Promise<T> {
-  tsNodeRegister(modulePath, tsConfig, logger);
+export async function loadModule<T>(modulePath: string, tsConfig: string): Promise<T> {
+  const absoluteModulePath = url.pathToFileURL(modulePath).pathname;
 
   switch (path.extname(modulePath)) {
     case '.mjs':
       // Load the ESM configuration file using the TypeScript dynamic import workaround.
       // Once TypeScript provides support for keeping the dynamic import this workaround can be
       // changed to a direct dynamic import.
-      return (await loadEsmModule<{ default: T }>(url.pathToFileURL(modulePath))).default;
+      return await import(absoluteModulePath).then(m => m.default);
+
     case '.cjs':
       return require(modulePath);
+
     case '.ts':
+      const unregisterTsProject = registerTsProject(tsConfig);
+
       try {
         // If it's a TS file then there are 2 cases for exporting an object.
         // The first one is `export blah`, transpiled into `module.exports = { blah} `.
@@ -105,10 +32,13 @@ export async function loadModule<T>(
           // Load the ESM configuration file using the TypeScript dynamic import workaround.
           // Once TypeScript provides support for keeping the dynamic import this workaround can be
           // changed to a direct dynamic import.
-          return (await loadEsmModule<{ default: T }>(url.pathToFileURL(modulePath))).default;
+          return await import(absoluteModulePath).then(m => m.default);
         }
         throw e;
+      } finally {
+        unregisterTsProject();
       }
+
     //.js
     default:
       // The file could be either CommonJS or ESM.
@@ -120,26 +50,10 @@ export async function loadModule<T>(
           // Load the ESM configuration file using the TypeScript dynamic import workaround.
           // Once TypeScript provides support for keeping the dynamic import this workaround can be
           // changed to a direct dynamic import.
-          return (await loadEsmModule<{ default: T }>(url.pathToFileURL(modulePath))).default;
+          return await import(absoluteModulePath).then(m => m.default);
         }
 
         throw e;
       }
   }
-}
-
-/**
- * Loads `ts-node` lazily. Moved to a separate function to declare
- * a return type, more readable than an inline variant.
- */
-function loadTsNode(): typeof import('ts-node') {
-  return require('ts-node');
-}
-
-/**
- * Loads `tsconfig-paths` lazily. Moved to a separate function to declare
- * a return type, more readable than an inline variant.
- */
-function loadTsConfigPaths(): typeof import('tsconfig-paths') {
-  return require('tsconfig-paths');
 }

--- a/packages/common/src/register-ts-project.ts
+++ b/packages/common/src/register-ts-project.ts
@@ -1,0 +1,68 @@
+let isTsEsmLoaderRegistered = false;
+
+export function registerTsProject(tsConfig: string) {
+  const cleanupFunctions = [registerTsConfigPaths(tsConfig), registerTsNodeService(tsConfig)];
+
+  // Add ESM support for `.ts` files.
+  // NOTE: There is no cleanup function for this, as it's not possible to unregister the loader.
+  //       Based on limited testing, it doesn't seem to matter if we register it multiple times, but just in
+  //       case let's keep a flag to prevent it.
+  if (!isTsEsmLoaderRegistered) {
+    const module = require('node:module');
+    if (module.register && packageIsInstalled('ts-node/esm')) {
+      const url = require('node:url');
+      module.register(url.pathToFileURL(require.resolve('ts-node/esm')));
+    }
+    isTsEsmLoaderRegistered = true;
+  }
+
+  return () => {
+    cleanupFunctions.forEach(fn => fn());
+  };
+}
+
+function registerTsNodeService(tsConfig: string): VoidFunction {
+  const { register } = require('ts-node') as typeof import('ts-node');
+
+  const service = register({
+    transpileOnly: true,
+    project: tsConfig,
+    compilerOptions: {
+      module: 'CommonJS',
+      types: [
+        'node', // NOTE: `node` is added because users scripts can also use pure node's packages as webpack or others
+      ],
+    },
+  });
+
+  return () => {
+    service.enabled(false);
+  };
+}
+
+function registerTsConfigPaths(tsConfig: string): VoidFunction {
+  const tsConfigPaths = require('tsconfig-paths') as typeof import('tsconfig-paths');
+  const result = tsConfigPaths.loadConfig(tsConfig);
+  if (result.resultType === 'success') {
+    const { absoluteBaseUrl: baseUrl, paths } = result;
+    if (baseUrl && paths) {
+      // Returns a function to undo paths registration.
+      return tsConfigPaths.register({ baseUrl, paths });
+    }
+  }
+
+  // We cannot return anything here if paths failed to be registered.
+  // Additionally, I don't think we should perform any logging in this
+  // context, considering that this is internal information not exposed
+  // to the end user
+  return () => {};
+}
+
+function packageIsInstalled(m: string): boolean {
+  try {
+    require.resolve(m);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/common/src/register-ts-project.ts
+++ b/packages/common/src/register-ts-project.ts
@@ -14,13 +14,19 @@ function registerTsNodeService(tsConfig: string): VoidFunction {
     project: tsConfig,
     compilerOptions: {
       module: 'CommonJS',
-      // Override moduleResolution to 'node' so it is compatible with module: 'CommonJS'.
-      // User tsconfigs may specify moduleResolution: 'bundler' or 'Node16' which are
-      // incompatible with module: 'CommonJS' in transpileOnly mode (TS5095, TS5110).
-      // This override only affects ts-node transpilation, not type checking.
+      // moduleResolution: 'node' is paired with module: 'CommonJS' above.
+      //
+      // Without this override, user tsconfigs declaring moduleResolution: 'bundler'
+      // or 'Node16' raise TS5095/TS5110 against the forced module: 'CommonJS'.
+      //
+      // Safe under transpileOnly: true — ts-node only transpiles, never resolves
+      // imports against this setting. The user's tsconfig still governs editor and
+      // build-time type checking. See PR #1659 and the regression it addresses
+      // (#1197, #1213). PR #2187 previously removed this override because it broke
+      // path resolution for user code; transpileOnly makes that case moot.
       moduleResolution: 'node',
       types: [
-        'node', // NOTE: `node` is added because users scripts can also use pure node's packages as webpack or others
+        'node', // user scripts (e.g. webpack.config) commonly require node builtins
       ],
     },
   });

--- a/packages/common/src/register-ts-project.ts
+++ b/packages/common/src/register-ts-project.ts
@@ -1,20 +1,5 @@
-let isTsEsmLoaderRegistered = false;
-
 export function registerTsProject(tsConfig: string) {
   const cleanupFunctions = [registerTsConfigPaths(tsConfig), registerTsNodeService(tsConfig)];
-
-  // Add ESM support for `.ts` files.
-  // NOTE: There is no cleanup function for this, as it's not possible to unregister the loader.
-  //       Based on limited testing, it doesn't seem to matter if we register it multiple times, but just in
-  //       case let's keep a flag to prevent it.
-  if (!isTsEsmLoaderRegistered) {
-    const module = require('node:module');
-    if (module.register && packageIsInstalled('ts-node/esm')) {
-      const url = require('node:url');
-      module.register(url.pathToFileURL(require.resolve('ts-node/esm')));
-    }
-    isTsEsmLoaderRegistered = true;
-  }
 
   return () => {
     cleanupFunctions.forEach(fn => fn());
@@ -29,6 +14,11 @@ function registerTsNodeService(tsConfig: string): VoidFunction {
     project: tsConfig,
     compilerOptions: {
       module: 'CommonJS',
+      // Override moduleResolution to 'node' so it is compatible with module: 'CommonJS'.
+      // User tsconfigs may specify moduleResolution: 'bundler' or 'Node16' which are
+      // incompatible with module: 'CommonJS' in transpileOnly mode (TS5095, TS5110).
+      // This override only affects ts-node transpilation, not type checking.
+      moduleResolution: 'node',
       types: [
         'node', // NOTE: `node` is added because users scripts can also use pure node's packages as webpack or others
       ],
@@ -56,13 +46,4 @@ function registerTsConfigPaths(tsConfig: string): VoidFunction {
   // context, considering that this is internal information not exposed
   // to the end user
   return () => {};
-}
-
-function packageIsInstalled(m: string): boolean {
-  try {
-    require.resolve(m);
-    return true;
-  } catch {
-    return false;
-  }
 }

--- a/packages/common/tests/fixtures/concurrent-a.ts
+++ b/packages/common/tests/fixtures/concurrent-a.ts
@@ -1,0 +1,1 @@
+export default { name: 'concurrent-a', value: 1 };

--- a/packages/common/tests/fixtures/concurrent-b.ts
+++ b/packages/common/tests/fixtures/concurrent-b.ts
@@ -1,0 +1,1 @@
+export default { name: 'concurrent-b', value: 2 };

--- a/packages/common/tests/fixtures/simple.ts
+++ b/packages/common/tests/fixtures/simple.ts
@@ -1,0 +1,1 @@
+export default { name: 'simple', value: 42 };

--- a/packages/common/tests/fixtures/tsconfig.bundler.json
+++ b/packages/common/tests/fixtures/tsconfig.bundler.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "module": "node16",
+    "moduleResolution": "node16"
   },
   "files": [
     "src/index.ts"

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "files": [
     "src/index.ts"

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "module": "node16",
-    "moduleResolution": "node16"
+    "outDir": "dist"
   },
   "files": [
     "src/index.ts"

--- a/packages/custom-esbuild/src/application/index.ts
+++ b/packages/custom-esbuild/src/application/index.ts
@@ -20,7 +20,6 @@ export function buildCustomEsbuildApplication(
       options.plugins,
       workspaceRoot,
       tsConfig,
-      context.logger,
       options,
       context.target
     );
@@ -29,7 +28,6 @@ export function buildCustomEsbuildApplication(
       ? await loadIndexHtmlTransformer(
           path.join(workspaceRoot, options.indexHtmlTransformer),
           tsConfig,
-          context.logger,
           context.target
         )
       : undefined;

--- a/packages/custom-esbuild/src/dev-server/index.ts
+++ b/packages/custom-esbuild/src/dev-server/index.ts
@@ -45,8 +45,7 @@ export function executeCustomDevServerBuilder(
         middleware.push(
           await loadModule<Middleware>(
             path.join(workspaceRoot, middlewarePath),
-            tsConfig,
-            context.logger
+            tsConfig
           )
         );
       }
@@ -55,7 +54,6 @@ export function executeCustomDevServerBuilder(
         buildOptions.plugins,
         workspaceRoot,
         tsConfig,
-        context.logger,
         options,
         context.target
       );
@@ -64,7 +62,6 @@ export function executeCustomDevServerBuilder(
         ? await loadIndexHtmlTransformer(
             path.join(workspaceRoot, buildOptions.indexHtmlTransformer),
             tsConfig,
-            context.logger,
             context.target
           )
         : undefined;

--- a/packages/custom-esbuild/src/load-index-html-transformer.spec.ts
+++ b/packages/custom-esbuild/src/load-index-html-transformer.spec.ts
@@ -14,7 +14,6 @@ describe('loadIndexHtmlTransformer', () => {
     const transform = await loadIndexHtmlTransformer(
       'test/test-index-transform.js',
       './tsconfig.json',
-      null as any,
       mockTarget
     );
 

--- a/packages/custom-esbuild/src/load-index-html-transformer.ts
+++ b/packages/custom-esbuild/src/load-index-html-transformer.ts
@@ -1,18 +1,15 @@
 import { loadModule } from '@angular-builders/common';
-import { logging } from '@angular-devkit/core';
 import { Target } from '@angular-devkit/architect';
 import type { IndexHtmlTransform } from '@angular/build/private';
 
 export async function loadIndexHtmlTransformer(
   indexHtmlTransformerPath: string,
   tsConfig: string,
-  logger: logging.LoggerApi,
   target: Target
 ): Promise<IndexHtmlTransform> {
   const transformer = await loadModule<(indexHtml: string, target: Target) => Promise<string>>(
     indexHtmlTransformerPath,
-    tsConfig,
-    logger
+    tsConfig
   );
   return (indexHtml: string) => transformer(indexHtml, target);
 }

--- a/packages/custom-esbuild/src/load-plugin.spec.ts
+++ b/packages/custom-esbuild/src/load-plugin.spec.ts
@@ -16,7 +16,6 @@ describe('loadPlugin', () => {
       ['test-plugin.js'],
       './test',
       './tsconfig.json',
-      null as any,
       {} as any,
       {} as any
     );
@@ -34,7 +33,6 @@ describe('loadPlugin', () => {
       ['test-plugin.js'],
       './test',
       './tsconfig.json',
-      null as any,
       mockOptions,
       mockTarget
     );
@@ -52,7 +50,6 @@ describe('loadPlugin', () => {
       [{ path: 'test-plugin.js', options: { test: 'test' } }],
       './test',
       './tsconfig.json',
-      null as any,
       mockOptions,
       mockTarget
     );

--- a/packages/custom-esbuild/src/load-plugins.ts
+++ b/packages/custom-esbuild/src/load-plugins.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path';
 import type { Plugin } from 'esbuild';
-import type { logging } from '@angular-devkit/core';
 import { loadModule } from '@angular-builders/common';
 import {
   CustomEsbuildApplicationSchema,
@@ -14,7 +13,6 @@ export async function loadPlugins(
   pluginConfig: PluginConfig[] | undefined,
   workspaceRoot: string,
   tsConfig: string,
-  logger: logging.LoggerApi,
   builderOptions: CustomEsbuildApplicationSchema | CustomEsbuildDevServerSchema | CustomEsbuildUnitTestSchema,
   target: Target
 ): Promise<Plugin[]> {
@@ -28,7 +26,7 @@ export async function loadPlugins(
               options: CustomEsbuildApplicationSchema | CustomEsbuildDevServerSchema | CustomEsbuildUnitTestSchema,
               target: Target
             ) => Plugin | Plugin[])
-        >(path.join(workspaceRoot, pluginConfig), tsConfig, logger);
+        >(path.join(workspaceRoot, pluginConfig), tsConfig);
         if (typeof pluginsOrFactory === 'function') {
           return pluginsOrFactory(builderOptions, target);
         } else {
@@ -37,8 +35,7 @@ export async function loadPlugins(
       } else {
         const pluginFactory = await loadModule<(...args: any[]) => Plugin>(
           path.join(workspaceRoot, pluginConfig.path),
-          tsConfig,
-          logger
+          tsConfig
         );
         return pluginFactory(pluginConfig.options, builderOptions, target);
       }

--- a/packages/custom-esbuild/src/unit-test/index.ts
+++ b/packages/custom-esbuild/src/unit-test/index.ts
@@ -35,7 +35,6 @@ export function executeCustomEsbuildUnitTestBuilder(
         buildOptions.plugins,
         workspaceRoot,
         tsConfig,
-        context.logger,
         options,
         context.target
       );

--- a/packages/custom-webpack/src/custom-webpack-builder.ts
+++ b/packages/custom-webpack/src/custom-webpack-builder.ts
@@ -47,8 +47,7 @@ export class CustomWebpackBuilder {
     );
     const configOrFactoryOrPromise = await loadModule<CustomWebpackConfig>(
       webpackConfigPath,
-      tsConfig,
-      logger
+      tsConfig
     );
 
     if (typeof configOrFactoryOrPromise === 'function') {

--- a/packages/custom-webpack/src/transform-factories.spec.ts
+++ b/packages/custom-webpack/src/transform-factories.spec.ts
@@ -1,8 +1,12 @@
 jest.mock('ts-node', () => ({
-  register: jest.fn(),
+  register: jest.fn().mockReturnValue({
+    enabled: jest.fn(),
+  }),
 }));
 jest.mock('tsconfig-paths', () => ({
-  loadConfig: jest.fn().mockReturnValue({}),
+  loadConfig: jest.fn().mockReturnValue({
+    register: jest.fn().mockReturnValue(() => {}),
+  }),
 }));
 import { getTransforms } from './transform-factories';
 
@@ -32,14 +36,6 @@ describe('getTransforms', () => {
     transforms.webpackConfiguration({});
 
     expect(tsNode.register).toHaveBeenCalledTimes(1);
-    expect(tsNode.register).toHaveBeenCalledWith({
-      project: 'test/tsconfig.test.json',
-      compilerOptions: {
-        module: 'CommonJS',
-        types: ['node'],
-      },
-    });
-    expect(logger.warn).not.toHaveBeenCalled();
 
     const transforms2 = getTransforms(
       {
@@ -52,7 +48,5 @@ describe('getTransforms', () => {
       { workspaceRoot: './test', logger } as any
     );
     transforms2.webpackConfiguration({});
-
-    expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/custom-webpack/src/transform-factories.spec.ts
+++ b/packages/custom-webpack/src/transform-factories.spec.ts
@@ -36,6 +36,15 @@ describe('getTransforms', () => {
     transforms.webpackConfiguration({});
 
     expect(tsNode.register).toHaveBeenCalledTimes(1);
+    expect(tsNode.register).toHaveBeenCalledWith({
+      transpileOnly: true,
+      project: 'test/tsconfig.test.json',
+      compilerOptions: {
+        module: 'CommonJS',
+        moduleResolution: 'node',
+        types: ['node'],
+      },
+    });
 
     const transforms2 = getTransforms(
       {

--- a/packages/custom-webpack/src/transform-factories.ts
+++ b/packages/custom-webpack/src/transform-factories.ts
@@ -32,19 +32,14 @@ export const customWebpackConfigTransformFactory: (
 export const indexHtmlTransformFactory: (
   options: CustomWebpackSchema,
   context: BuilderContext
-) => IndexHtmlTransform = (options, { workspaceRoot, target, logger }) => {
+) => IndexHtmlTransform = (options, { workspaceRoot, target }) => {
   if (!options.indexTransform) return null;
 
   const transformPath = path.join(getSystemPath(normalize(workspaceRoot)), options.indexTransform);
   const tsConfig = path.join(getSystemPath(normalize(workspaceRoot)), options.tsConfig);
 
   return async (indexHtml: string) => {
-    const transform = await loadModule<IndexHtmlTransformWithOptions>(
-      transformPath,
-      tsConfig,
-      logger
-    );
-
+    const transform = await loadModule<IndexHtmlTransformWithOptions>(transformPath, tsConfig);
     return transform(target, indexHtml);
   };
 };

--- a/packages/jest/src/custom-config.resolver.ts
+++ b/packages/jest/src/custom-config.resolver.ts
@@ -33,7 +33,7 @@ export class CustomConfigResolver {
       return {};
     }
 
-    return await loadModule<JestConfig>(workspaceJestConfigPath, tsConfig, this.logger);
+    return await loadModule<JestConfig>(workspaceJestConfigPath, tsConfig);
   }
 
   async resolveForProject(projectRoot: Path, config: string | JestConfig): Promise<JestConfig> {
@@ -60,7 +60,7 @@ export class CustomConfigResolver {
       return {};
     }
     const tsConfig = getTsConfigPath(projectRoot, this.options);
-    return await loadModule<JestConfig>(jestConfigPath, tsConfig, this.logger);
+    return await loadModule<JestConfig>(jestConfigPath, tsConfig);
   }
 
   private tryParseJsonConfig(config: string): JestConfig | null {

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,7 +188,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@angular-builders/common@workspace:packages/common"
   dependencies:
-    "@angular-devkit/core": ^21.0.0
     rimraf: ^6.0.0
     ts-node: ^10.0.0
     tsconfig-paths: ^4.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -19809,6 +19809,7 @@ __metadata:
     rxjs: 7.8.2
     tslib: 2.8.1
     typescript: 5.9.3
+    webpack-esm-plugin: "file:./webpack-esm-plugin"
     zone.js: 0.16.2
   languageName: unknown
   linkType: soft
@@ -22809,6 +22810,13 @@ __metadata:
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
   checksum: 2b7f2096529945f578e86966d9a0994b0a87b82e3bb3a7cd1ccea2fb81aa95724473a88c9b2033ae3d2f799d13330342948ea77638029d10c8c0c746aac545f7
+  languageName: node
+  linkType: hard
+
+"webpack-esm-plugin@file:./webpack-esm-plugin::locator=sanity-app-esm%40workspace%3Aexamples%2Fcustom-webpack%2Fsanity-app-esm":
+  version: 0.0.1
+  resolution: "webpack-esm-plugin@file:./webpack-esm-plugin#./webpack-esm-plugin::hash=cc78ab&locator=sanity-app-esm%40workspace%3Aexamples%2Fcustom-webpack%2Fsanity-app-esm"
+  checksum: 7561a04e33c90be5846cf08d2882f0f662e5d4b25fa66954e32f77d0d7aee73a0cb1a9dcf275559bac39f04a88da23e330e750025e0e7b248da1eca090241b5b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When loading `.ts` config/plugin files, ts-node is registered once per process. If two projects use different tsconfig files, the second registration is silently skipped with a warning, meaning the wrong tsconfig may be used. Additionally, registering ts-node with `module: 'CommonJS'` while the user's tsconfig specifies `moduleResolution: 'bundler'` or `'Node16'` caused TS5095/TS5110 errors.

Closes #1197, #1213

## What is the new behavior?

- ts-node is registered and unregistered around each `.ts` file load (register → require → unregister), so each load uses the correct project tsconfig
- `moduleResolution: 'node'` is added to the ts-node compiler options override to avoid TS5095/TS5110 conflicts when users specify `moduleResolution: 'bundler'` or `'Node16'`; this is safe under `transpileOnly: true` (no type-check semantics depend on it)
- The `@angular-devkit/core` logger dependency is removed from `common`; the logger parameter is removed from `loadModule()`
- Added integration test fixture: ESM package import from TypeScript webpack config (`webpack-esm-plugin` local package with CJS + ESM exports)

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

The `loadModule()` signature change (removing the `logger` parameter) is a breaking change for external consumers. The register/unregister-per-load model is also a behavior change: `service.enabled(false)` disables the require hook process-wide, so concurrent loads can race. To be shipped in the next major.

## Other information

Originally authored by @arturovt. Rebased and fixed to resolve CI failures (TS5095/TS5110 moduleResolution conflict, missing `webpack-esm-plugin` CJS entry, removed ESM hook that caused TypeError in Angular build context).