### PR TITLE
fix(custom-esbuild): add type to schema extension

### DIFF
--- a/packages/custom-esbuild/src/application/schema.ext.json
+++ b/packages/custom-esbuild/src/application/schema.ext.json
@@ -4,6 +4,7 @@
   "description": "Application target options",
   "properties": {
     "plugins": {
+      "type": "array",
       "description": "A list of paths to ESBuild plugins",
       "default": [],
       "items": {

--- a/packages/custom-esbuild/src/dev-server/schema.ext.json
+++ b/packages/custom-esbuild/src/dev-server/schema.ext.json
@@ -4,6 +4,7 @@
   "description": "Dev server target options",
   "properties": {
     "middlewares": {
+      "type": "array",
       "description": "A list of paths to Vite server middlewares",
       "default": [],
       "items": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [ ] ~Docs have been added / updated (for bug fixes / features)~

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

I encountered an issue while trying to use `@angular-builders/custom-esbuild:dev-server` along with `@nx/cypress:cypress`.

Our app could not be started through `nx run ....` command (`ng serve` works fine), because of error:
```
   Are you sure this is a valid target?
   Was trying to read the target for the property: 'watch', but got the following error: 
   Property 'middlewares' does not match the schema.
   {
     "description": "A list of paths to Vite server middlewares",
     "default": [],
     "items": {
       "type": "string",
       "uniqueItems": true
     }
   }'
```

Somehow `nx/cli` schema validation is more strict than `ng/cli` (I didn't dig deeper why)


## What is the new behavior?

I fixed it manually by adding `type:"array"` to `schema.json`. It works both with `ng/cli` and `nx/cli`.
This PR adds `type:"array"` to schema extension.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

cc: @just-jeb _(it's quite blocking issue for our migration from webpack to esbuild)_