### PR TITLE
docs: fix angular version typo on 15.x.x

### DIFF
--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -26,7 +26,7 @@ The builder comes to provide zero configuration setup for Jest while keeping the
 
 ## Prerequisites
 
-- [Angular CLI 14](https://www.npmjs.com/package/@angular/cli)
+- [Angular CLI 15](https://www.npmjs.com/package/@angular/cli)
 - [Jest 28](https://www.npmjs.com/package/jest)
 
 ## Installation


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently I was upgrading  an older version of @angular-builders/jest@15  and got confused by the docs (on tag `15.x.x`), saying that it needs Angular 14, when the peer dependencies says that it needs Angular v15.

https://github.com/just-jeb/angular-builders/blob/a3bfedc81d3422f810225245cc048f0373a05e65/packages/jest/package.json#L44-L46


## What is the new behavior?

The `README` says the correct Angular v15 version that it needs.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
