### PR TITLE
ci: migrate to npm trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     if: (!contains(github.event.head_commit.message, 'ci(release)'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     strategy:
       fail-fast: true
 
@@ -44,11 +47,8 @@ jobs:
 
       - name: Publish to NPM
         if: github.ref == 'refs/heads/master'
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          git reset --hard	
+          git reset --hard
           git config --global user.name ${{ secrets.GIT_USER }}
           git config --global user.email ${{ secrets.GIT_EMAIL }}
-          npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
           bash scripts/default-registry.sh

--- a/.github/workflows/graduate.yml
+++ b/.github/workflows/graduate.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build_and_graduate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     strategy:
       fail-fast: true
 
@@ -35,11 +38,8 @@ jobs:
         run: yarn ci
 
       - name: Graduate beta release to NPM
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          git reset --hard	
+          git reset --hard
           git config --global user.name ${{ secrets.GIT_USER }}
           git config --global user.email ${{ secrets.GIT_EMAIL }}
-          npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          npm run graduate -- --yes
+          npm run graduate -- --yes --provenance

--- a/scripts/default-registry.sh
+++ b/scripts/default-registry.sh
@@ -1,4 +1,4 @@
 
 #!/bin/bash
 
-yarn lerna publish --dist-tag=next --preid=beta --conventional-prerelease --yes
+yarn lerna publish --dist-tag=next --preid=beta --conventional-prerelease --yes --provenance


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

CI uses NPM_TOKEN secret for publishing packages to npm. Classic tokens have been revoked by npm and granular tokens expire every 90 days.

Issue Number: N/A

## What is the new behavior?

Uses npm Trusted Publishing with OpenID Connect (OIDC) - no tokens needed, more secure.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

**Prerequisites before merging:**
Set up Trusted Publisher on npm for each package at `https://www.npmjs.com/package/@angular-builders/<pkg>/access`:
- Workflow: `ci.yml`
- Organization: `just-jeb`
- Repository: `angular-builders`

After merging, the `NPM_TOKEN` secret can be deleted from GitHub.