### PR TITLE
fix(common): add missing repository field for npm provenance validation

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -11,6 +11,10 @@
   },
   "author": "JeB Barabanov",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/just-jeb/angular-builders"
+  },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

After upgrading to lerna-lite v4.10.5 for OIDC Trusted Publishing, npm publish fails for `@angular-builders/common` with:

```
E422 Error verifying sigstore provenance bundle: Failed to validate repository information: 
package.json: "repository.url" is "", expected to match "https://github.com/just-jeb/angular-builders" from provenance
```

Issue Number: N/A

## What is the new behavior?

Added the missing `repository` field to `packages/common/package.json`. This field is required for npm's OIDC provenance validation to work.

All other packages already have this field defined.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

This is a follow-up fix after #1978 (lerna-lite upgrade for OIDC).