### PR TITLE
fix(jest): matchMedia mock survives resetMocks option

### DIFF
--- a/packages/jest/src/global-mocks/match-media.spec.ts
+++ b/packages/jest/src/global-mocks/match-media.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the matchMedia mock with resetMocks behavior
+ *
+ * This test verifies the fix for issue #1983:
+ * https://github.com/just-jeb/angular-builders/issues/1983
+ *
+ * When using resetMocks: true, jest.fn().mockImplementation() gets cleared
+ * before each test, causing matchMedia to return undefined. The fix uses
+ * a regular function instead, which survives resetMocks.
+ *
+ * @jest-environment jsdom
+ */
+
+// Import the matchMedia mock setup
+import './match-media';
+
+describe('matchMedia mock survives jest.resetAllMocks()', () => {
+  beforeEach(() => {
+    // Simulate what Jest's resetMocks: true does before each test
+    jest.resetAllMocks();
+  });
+
+  it('should return a valid MediaQueryList object', () => {
+    const mql = window.matchMedia('(min-width: 768px)');
+
+    expect(mql).toBeDefined();
+    expect(mql.matches).toBe(false);
+    expect(mql.media).toBe('(min-width: 768px)');
+    expect(typeof mql.addEventListener).toBe('function');
+    expect(typeof mql.removeEventListener).toBe('function');
+  });
+
+  it('should still return valid object after resetAllMocks runs', () => {
+    // This test runs after jest.resetAllMocks() clears all mocks
+    // Before the fix, matchMedia() would return undefined here
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+
+    expect(mql).toBeDefined();
+    expect(mql.matches).toBe(false);
+    expect(mql.media).toBe('(prefers-color-scheme: dark)');
+  });
+
+  it('should work in third consecutive test', () => {
+    const mql = window.matchMedia('screen');
+
+    expect(mql).toBeDefined();
+    expect(mql.matches).toBe(false);
+  });
+
+  it('should have callable mock methods on returned object', () => {
+    const mql = window.matchMedia('test');
+    const callback = jest.fn();
+
+    // The inner methods should still be jest mocks
+    mql.addEventListener('change', callback);
+    expect(mql.addEventListener).toHaveBeenCalledWith('change', callback);
+  });
+});

--- a/packages/jest/src/global-mocks/match-media.ts
+++ b/packages/jest/src/global-mocks/match-media.ts
@@ -1,6 +1,9 @@
+// Use a regular function instead of jest.fn().mockImplementation() to survive
+// Jest's resetMocks option, which removes mock implementations before each test.
+// See: https://github.com/just-jeb/angular-builders/issues/1983
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: jest.fn().mockImplementation(query => ({
+  value: (query: string) => ({
     matches: false,
     media: query,
     onchange: null,
@@ -9,5 +12,5 @@ Object.defineProperty(window, 'matchMedia', {
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
-  })),
+  }),
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When using `resetMocks: true` in Jest configuration, the `matchMedia` mock returns `undefined` because `jest.fn().mockImplementation()` gets cleared before each test.

Closes issue: #1983

## What is the new behavior?

The `matchMedia` mock now uses a regular function instead of `jest.fn().mockImplementation()`. This survives Jest's `resetMocks` option while still providing `jest.fn()` methods on the returned object for test assertions.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

- Added unit test that verifies `matchMedia` works with `resetMocks: true`
- Test fails with old implementation (returns `undefined`), passes with fix
- Inner mock methods (`addEventListener`, `removeEventListener`, etc.) remain as `jest.fn()` for assertion purposes