### PR TITLE
ci: replace approval apps with single auto-approve workflow

### DIFF
--- a/.github/autoapproval.yml
+++ b/.github/autoapproval.yml
@@ -1,7 +1,0 @@
-from_owner:
-  - just-jeb
-  - renovate[bot]
-  - allcontributors[bot]
-apply_labels:
-  - autoapproved
-required_labels: []

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,17 @@
+name: Auto Approve
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: |
+      github.actor == 'just-jeb' ||
+      github.actor == 'renovate[bot]' ||
+      github.actor == 'allcontributors[bot]'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v4


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Dependency and contributor PRs are auto-approved via two GitHub Apps (renovate-approve and autoapproval) plus `.github/autoapproval.yml`.

Issue Number: N/A

## What is the new behavior?

A single GitHub Actions workflow (`.github/workflows/auto-approve.yml`) approves PRs from `just-jeb`, `renovate[bot]`, and `allcontributors[bot]` using `hmarr/auto-approve-action`. The `autoapproval.yml` config is removed. After merging, the renovate-approve and autoapproval apps can be uninstalled from the repo.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information