### PR TITLE
fix(bazel): pin Angular CLI version to match other examples

### DIFF
--- a/examples/bazel/package.json
+++ b/examples/bazel/package.json
@@ -7,6 +7,6 @@
   "private": true,
   "devDependencies": {
     "@angular-builders/bazel": "workspace:*",
-    "@angular/cli": "^21.1.1"
+    "@angular/cli": "21.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,18 +285,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/architect@npm:0.2101.1":
-  version: 0.2101.1
-  resolution: "@angular-devkit/architect@npm:0.2101.1"
-  dependencies:
-    "@angular-devkit/core": 21.1.1
-    rxjs: 7.8.2
-  bin:
-    architect: bin/cli.js
-  checksum: f59f5358905d1fb1338e2f92c85ec9b1cca57b7aa6e1c5988dc8f9a3cab5c19088b9ece262a266e4088beeeea507078e5eea56ac98434b7f20ef0a3da45d4066
-  languageName: node
-  linkType: hard
-
 "@angular-devkit/architect@npm:0.2101.2":
   version: 0.2101.2
   resolution: "@angular-devkit/architect@npm:0.2101.2"
@@ -607,25 +595,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/core@npm:21.1.1":
-  version: 21.1.1
-  resolution: "@angular-devkit/core@npm:21.1.1"
-  dependencies:
-    ajv: 8.17.1
-    ajv-formats: 3.0.1
-    jsonc-parser: 3.3.1
-    picomatch: 4.0.3
-    rxjs: 7.8.2
-    source-map: 0.7.6
-  peerDependencies:
-    chokidar: ^5.0.0
-  peerDependenciesMeta:
-    chokidar:
-      optional: true
-  checksum: 69910bc7f22010c2e94143b736d571b551b6a36a79b6d437f12da3c393a177716a5f1fbd8ebf1e0f99adab2822d10bdad7e8224674ead847ddc0ac691dd1bcce
-  languageName: node
-  linkType: hard
-
 "@angular-devkit/core@npm:21.1.2":
   version: 21.1.2
   resolution: "@angular-devkit/core@npm:21.1.2"
@@ -642,19 +611,6 @@ __metadata:
     chokidar:
       optional: true
   checksum: 9e714480612218d9943d494dbed4cfddd3d0d39f5170eaf9811ea6c516fccfde95750c6ae32f326e5187edf60cffb7763e9816f689a683ac39bbb2fc2c6f8b44
-  languageName: node
-  linkType: hard
-
-"@angular-devkit/schematics@npm:21.1.1":
-  version: 21.1.1
-  resolution: "@angular-devkit/schematics@npm:21.1.1"
-  dependencies:
-    "@angular-devkit/core": 21.1.1
-    jsonc-parser: 3.3.1
-    magic-string: 0.30.21
-    ora: 9.0.0
-    rxjs: 7.8.2
-  checksum: da2a4605a5c2ede07090cc655f68af9cd5d328d33e1a246a29c05f070b086cd80a61362076468832c1880e59ee178432db1121369a854ecb07dc0a7a83f61c76
   languageName: node
   linkType: hard
 
@@ -977,35 +933,6 @@ __metadata:
   bin:
     ng: bin/ng.js
   checksum: 47cc75c834db3a9e3241e76405ebcb9701b056cc57ddd48b3ad885c97bda8c8ae1b11c63e962ecf491bc5b7a037536a3476baa6aefd809c77d31838462bf59b2
-  languageName: node
-  linkType: hard
-
-"@angular/cli@npm:^21.1.1":
-  version: 21.1.1
-  resolution: "@angular/cli@npm:21.1.1"
-  dependencies:
-    "@angular-devkit/architect": 0.2101.1
-    "@angular-devkit/core": 21.1.1
-    "@angular-devkit/schematics": 21.1.1
-    "@inquirer/prompts": 7.10.1
-    "@listr2/prompt-adapter-inquirer": 3.0.5
-    "@modelcontextprotocol/sdk": 1.25.2
-    "@schematics/angular": 21.1.1
-    "@yarnpkg/lockfile": 1.1.0
-    algoliasearch: 5.46.2
-    ini: 6.0.0
-    jsonc-parser: 3.3.1
-    listr2: 9.0.5
-    npm-package-arg: 13.0.2
-    pacote: 21.0.4
-    parse5-html-rewriting-stream: 8.0.0
-    resolve: 1.22.11
-    semver: 7.7.3
-    yargs: 18.0.0
-    zod: 4.3.5
-  bin:
-    ng: bin/ng.js
-  checksum: d0dccae203f4118b5a9736fe0ab2beffa54a5120a12f0370e74b514a459ce90cd071ed5fdd9932a43ad5e2d17053426526870e45fe099b2db44262c2b4ae179a
   languageName: node
   linkType: hard
 
@@ -6768,17 +6695,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@schematics/angular@npm:21.1.1":
-  version: 21.1.1
-  resolution: "@schematics/angular@npm:21.1.1"
-  dependencies:
-    "@angular-devkit/core": 21.1.1
-    "@angular-devkit/schematics": 21.1.1
-    jsonc-parser: 3.3.1
-  checksum: 298a5b00f7678aa2069c81bf55b60543da187ece3fb53934688a487a48ed67cb67703634cdec5042e425b3b5bbc4f1828459b17dd9380c57e0e8d8460c67e844
-  languageName: node
-  linkType: hard
-
 "@schematics/angular@npm:21.1.2":
   version: 21.1.2
   resolution: "@schematics/angular@npm:21.1.2"
@@ -9005,7 +8921,7 @@ __metadata:
   resolution: "bazel-example@workspace:examples/bazel"
   dependencies:
     "@angular-builders/bazel": "workspace:*"
-    "@angular/cli": ^21.1.1
+    "@angular/cli": 21.1.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Pin `@angular/cli` in bazel example from `^21.1.1` to `21.1.2` (matching other examples)
- Removes duplicate Angular CLI version from yarn.lock (86 lines)

## Problem

The bazel example had `@angular/cli: ^21.1.1` (caret version) while all other examples use pinned `21.1.2`. This caused:

1. **Version split in yarn.lock**: Two different Angular CLI versions (21.1.1 and 21.1.2) were installed
2. **CI failure**: Yarn didn't properly set up workspace-specific `node_modules/@angular/cli` symlinks for the bazel example
3. **Error**: `Cannot find module '.../examples/bazel/node_modules/@angular/cli/bin/ng.js'`

## Root Cause

When Renovate updated Angular CLI to 21.1.2, it skipped the bazel example because `^21.1.1` already "allows" 21.1.2 (the constraint was satisfied). However, the yarn.lock still resolved `^21.1.1` to `21.1.1`, creating the version split.

## Fix

Pin bazel to `21.1.2` to match other examples, eliminating the duplicate dependency.

## Prevention

This was a one-time issue. The renovate.json already has `rangeStrategy: "pin"` for examples, which will prevent caret/tilde versions going forward. Renovate PR #1939 can be closed as this PR supersedes it with the correct version.