### PR TITLE
chore(renovate): configure aggressive rebasing for PRs behind base branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     "workarounds:all"
   ],
   "prHourlyLimit": 3,
+  "rebaseWhen": "behind-base-branch",
   "updateInternalDeps": true,
   "postUpdateOptions": ["yarnDedupeFewer"],
   "packageRules": [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Renovate uses the default `rebaseWhen: "auto"` which only rebases PRs when convenient (e.g., when ready to automerge). This causes PRs—especially major updates that require manual review—to remain "behind base branch" and stuck waiting for rebase.

Issue Number: N/A

## What is the new behavior?

With `rebaseWhen: "behind-base-branch"`, Renovate will proactively rebase all PRs whenever they fall behind the base branch. This ensures PRs stay up-to-date and ready to merge after review/approval.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

This change works well with the "require branches to be up to date" branch protection rule, as Renovate will automatically keep its PRs rebased rather than requiring manual intervention.