### PR TITLE
docs: remove dead v17 links and add version alignment note

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Builders' and Angular **major** versions **must** match.
 - [Version 20](https://github.com/just-jeb/angular-builders/tree/20.x.x)
 - [Version 19](https://github.com/just-jeb/angular-builders/tree/19.x.x)
 - [Version 18](https://github.com/just-jeb/angular-builders/tree/18.x.x)
-- [Version 17](https://github.com/just-jeb/angular-builders/tree/17.x.x)
 - [Version 16](https://github.com/just-jeb/angular-builders/tree/16.x.x)
 - [Version 15](https://github.com/just-jeb/angular-builders/tree/15.x.x)
 - [Version 14](https://github.com/just-jeb/angular-builders/tree/14.x.x)

--- a/packages/custom-esbuild/README.md
+++ b/packages/custom-esbuild/README.md
@@ -29,7 +29,6 @@ Allow customizing ESBuild configuration
 - [Version 20](https://github.com/just-jeb/angular-builders/blob/20.x.x/packages/custom-esbuild/README.md)
 - [Version 19](https://github.com/just-jeb/angular-builders/blob/19.x.x/packages/custom-esbuild/README.md)
 - [Version 18](https://github.com/just-jeb/angular-builders/blob/18.x.x/packages/custom-esbuild/README.md)
-- [Version 17](https://github.com/just-jeb/angular-builders/blob/17.x.x/packages/custom-esbuild/README.md)
 
 </details>
 

--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -28,6 +28,9 @@ Allow customizing build configuration without ejecting webpack configuration (`n
 
 # This documentation is for the latest major version only
 
+> ⚠️ **Version alignment:** The major version of `@angular-builders/custom-webpack` must match the major version of `@angular/core` in your project. For example, Angular 19 requires `@angular-builders/custom-webpack@19.x`, Angular 20 requires `@angular-builders/custom-webpack@20.x`, etc. Using a mismatched version is the most common source of issues.
+
+
 ## Previous versions
 
 <details>
@@ -36,7 +39,6 @@ Allow customizing build configuration without ejecting webpack configuration (`n
 - [Version 20](https://github.com/just-jeb/angular-builders/blob/20.x.x/packages/custom-webpack/README.md)
 - [Version 19](https://github.com/just-jeb/angular-builders/blob/19.x.x/packages/custom-webpack/README.md)
 - [Version 18](https://github.com/just-jeb/angular-builders/blob/18.x.x/packages/custom-webpack/README.md)
-- [Version 17](https://github.com/just-jeb/angular-builders/blob/17.x.x/packages/custom-webpack/README.md)
 - [Version 16](https://github.com/just-jeb/angular-builders/blob/16.x.x/packages/custom-webpack/README.md)
 - [Version 15](https://github.com/just-jeb/angular-builders/blob/15.x.x/packages/custom-webpack/README.md)
 - [Version 14](https://github.com/just-jeb/angular-builders/blob/14.x.x/packages/custom-webpack/README.md)

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -15,7 +15,6 @@ The builder comes to provide zero configuration setup for Jest while keeping the
 - [Version 20](https://github.com/just-jeb/angular-builders/blob/20.x.x/packages/jest/README.md)
 - [Version 19](https://github.com/just-jeb/angular-builders/blob/19.x.x/packages/jest/README.md)
 - [Version 18](https://github.com/just-jeb/angular-builders/blob/18.x.x/packages/jest/README.md)
-- [Version 17](https://github.com/just-jeb/angular-builders/blob/17.x.x/packages/jest/README.md)
 - [Version 16](https://github.com/just-jeb/angular-builders/blob/16.x.x/packages/jest/README.md)
 - [Version 15](https://github.com/just-jeb/angular-builders/blob/15.x.x/packages/jest/README.md)
 - [Version 14](https://github.com/just-jeb/angular-builders/blob/14.x.x/packages/jest/README.md)


### PR DESCRIPTION
## What

Two small docs fixes:

### Fix #1858 — Remove dead Version 17 links

The `17.x.x` branch does not exist in this repo. All 4 READMEs (root, custom-webpack, custom-esbuild, jest) had a dead link to it. Removed.

### Fix #899 — Add version alignment warning to custom-webpack README

Version mismatch (e.g. using `@angular-builders/custom-webpack@19` with Angular 20) is consistently the most common source of user issues. Added a prominent warning right below the "latest major version" notice.

## Changes
- `README.md` — removed v17 link
- `packages/custom-webpack/README.md` — removed v17 link + added version alignment note
- `packages/custom-esbuild/README.md` — removed v17 link
- `packages/jest/README.md` — removed v17 link

Closes #1858
Closes #899