### PR TITLE
docs: remove dead Version 17 links from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Builders' and Angular **major** versions **must** match.
 - [Version 20](https://github.com/just-jeb/angular-builders/tree/20.x.x)
 - [Version 19](https://github.com/just-jeb/angular-builders/tree/19.x.x)
 - [Version 18](https://github.com/just-jeb/angular-builders/tree/18.x.x)
-- [Version 17](https://github.com/just-jeb/angular-builders/tree/17.x.x)
 - [Version 16](https://github.com/just-jeb/angular-builders/tree/16.x.x)
 - [Version 15](https://github.com/just-jeb/angular-builders/tree/15.x.x)
 - [Version 14](https://github.com/just-jeb/angular-builders/tree/14.x.x)

--- a/packages/custom-esbuild/README.md
+++ b/packages/custom-esbuild/README.md
@@ -29,7 +29,6 @@ Allow customizing ESBuild configuration
 - [Version 20](https://github.com/just-jeb/angular-builders/blob/20.x.x/packages/custom-esbuild/README.md)
 - [Version 19](https://github.com/just-jeb/angular-builders/blob/19.x.x/packages/custom-esbuild/README.md)
 - [Version 18](https://github.com/just-jeb/angular-builders/blob/18.x.x/packages/custom-esbuild/README.md)
-- [Version 17](https://github.com/just-jeb/angular-builders/blob/17.x.x/packages/custom-esbuild/README.md)
 
 </details>
 

--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -36,7 +36,6 @@ Allow customizing build configuration without ejecting webpack configuration (`n
 - [Version 20](https://github.com/just-jeb/angular-builders/blob/20.x.x/packages/custom-webpack/README.md)
 - [Version 19](https://github.com/just-jeb/angular-builders/blob/19.x.x/packages/custom-webpack/README.md)
 - [Version 18](https://github.com/just-jeb/angular-builders/blob/18.x.x/packages/custom-webpack/README.md)
-- [Version 17](https://github.com/just-jeb/angular-builders/blob/17.x.x/packages/custom-webpack/README.md)
 - [Version 16](https://github.com/just-jeb/angular-builders/blob/16.x.x/packages/custom-webpack/README.md)
 - [Version 15](https://github.com/just-jeb/angular-builders/blob/15.x.x/packages/custom-webpack/README.md)
 - [Version 14](https://github.com/just-jeb/angular-builders/blob/14.x.x/packages/custom-webpack/README.md)

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -15,7 +15,6 @@ The builder comes to provide zero configuration setup for Jest while keeping the
 - [Version 20](https://github.com/just-jeb/angular-builders/blob/20.x.x/packages/jest/README.md)
 - [Version 19](https://github.com/just-jeb/angular-builders/blob/19.x.x/packages/jest/README.md)
 - [Version 18](https://github.com/just-jeb/angular-builders/blob/18.x.x/packages/jest/README.md)
-- [Version 17](https://github.com/just-jeb/angular-builders/blob/17.x.x/packages/jest/README.md)
 - [Version 16](https://github.com/just-jeb/angular-builders/blob/16.x.x/packages/jest/README.md)
 - [Version 15](https://github.com/just-jeb/angular-builders/blob/15.x.x/packages/jest/README.md)
 - [Version 14](https://github.com/just-jeb/angular-builders/blob/14.x.x/packages/jest/README.md)


### PR DESCRIPTION
The `17.x.x` branch does not exist in this repo, making the "Version 17" link in the previous versions sections a 404.

Removed from all four READMEs: root, `custom-webpack`, `custom-esbuild`, and `jest`.

Fixes #1858