### PR TITLE
docs: add version alignment warning to all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Builders' and Angular **major** versions **must** match.
 
 ## [Migration guide](./MIGRATION.MD)
 
+> ⚠️ **Version alignment:** The major version of `@angular-builders/*` packages must match the major version of `@angular/core` in your project. For example, Angular 19 requires `@angular-builders/*@19.x`, Angular 20 requires `@angular-builders/*@20.x`, etc. Using a mismatched version is the most common source of issues.
+
 ## Previous versions
 
 <details>

--- a/packages/custom-esbuild/README.md
+++ b/packages/custom-esbuild/README.md
@@ -21,6 +21,9 @@ Allow customizing ESBuild configuration
 
 # This documentation is for the latest major version only
 
+> ⚠️ **Version alignment:** The major version of `@angular-builders/custom-esbuild` must match the major version of `@angular/core` in your project. For example, Angular 19 requires `@angular-builders/custom-esbuild`@19.x, Angular 20 requires `@angular-builders/custom-esbuild`@20.x, etc. Using a mismatched version is the most common source of issues.
+
+
 ## Previous versions
 
 <details>

--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -28,6 +28,9 @@ Allow customizing build configuration without ejecting webpack configuration (`n
 
 # This documentation is for the latest major version only
 
+> ⚠️ **Version alignment:** The major version of `@angular-builders/custom-webpack` must match the major version of `@angular/core` in your project. For example, Angular 19 requires `@angular-builders/custom-webpack@19.x`, Angular 20 requires `@angular-builders/custom-webpack@20.x`, etc. Using a mismatched version is the most common source of issues.
+
+
 ## Previous versions
 
 <details>

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -7,6 +7,9 @@ The builder comes to provide zero configuration setup for Jest while keeping the
 
 # This documentation is for the latest major version only
 
+> ⚠️ **Version alignment:** The major version of `@angular-builders/jest` must match the major version of `@angular/core` in your project. For example, Angular 19 requires `@angular-builders/jest`@19.x, Angular 20 requires `@angular-builders/jest`@20.x, etc. Using a mismatched version is the most common source of issues.
+
+
 ## Previous versions
 
 <details>


### PR DESCRIPTION
Version mismatch between `@angular-builders/*` and `@angular/core` is the single most common source of user-reported issues (see e.g. #1930, #873, #992).

Adds a prominent warning to:
- Root `README.md`
- `packages/custom-webpack/README.md`
- `packages/custom-esbuild/README.md`
- `packages/jest/README.md`

Closes #899