### PR TITLE
fix(jest): pass findRelatedTests files as positional args

### DIFF
--- a/packages/jest/src/options-converter.spec.ts
+++ b/packages/jest/src/options-converter.spec.ts
@@ -31,4 +31,26 @@ describe('Convert options to Jest CLI arguments', () => {
     const argv = optionsConverter.convertToCliArgs({ '--': ['non-flag-1', 'non-flag-2'] } as any);
     expect(argv).toEqual(['non-flag-1 non-flag-2']);
   });
+
+  it('Should convert findRelatedTests into a boolean flag followed by positional file args', () => {
+    const argv = optionsConverter.convertToCliArgs({
+      findRelatedTests: ['src/app/foo.ts', 'src/app/bar.ts'],
+    } as any);
+    expect(argv).toEqual(['--findRelatedTests', 'src/app/foo.ts', 'src/app/bar.ts']);
+  });
+
+  it('Should correctly place findRelatedTests positional args after other flags', () => {
+    const argv = optionsConverter.convertToCliArgs({
+      watch: true,
+      findRelatedTests: ['src/app/foo.ts'],
+      coverage: false,
+    } as any);
+    expect(argv).toContain('--watch');
+    expect(argv).toContain('--findRelatedTests');
+    // Positional arg must come after --findRelatedTests flag, at the end
+    const frtIdx = argv.indexOf('--findRelatedTests');
+    const fileIdx = argv.indexOf('src/app/foo.ts');
+    expect(fileIdx).toBeGreaterThan(frtIdx);
+    expect(argv[argv.length - 1]).toBe('src/app/foo.ts');
+  });
 });

--- a/packages/jest/src/options-converter.spec.ts
+++ b/packages/jest/src/options-converter.spec.ts
@@ -32,25 +32,41 @@ describe('Convert options to Jest CLI arguments', () => {
     expect(argv).toEqual(['non-flag-1 non-flag-2']);
   });
 
-  it('Should convert findRelatedTests into a boolean flag followed by positional file args', () => {
-    const argv = optionsConverter.convertToCliArgs({
-      findRelatedTests: ['src/app/foo.ts', 'src/app/bar.ts'],
-    } as any);
-    expect(argv).toEqual(['--findRelatedTests', 'src/app/foo.ts', 'src/app/bar.ts']);
-  });
+  describe('findRelatedTests', () => {
+    it('Should split comma-separated string from Angular CLI into boolean flag + positional args', () => {
+      // Angular CLI passes comma-separated values as a single string for array schema fields
+      const argv = optionsConverter.convertToCliArgs({
+        findRelatedTests: 'src/app/foo.ts,src/app/bar.ts',
+      } as any);
+      expect(argv).toEqual(['--findRelatedTests', 'src/app/foo.ts', 'src/app/bar.ts']);
+    });
 
-  it('Should correctly place findRelatedTests positional args after other flags', () => {
-    const argv = optionsConverter.convertToCliArgs({
-      watch: true,
-      findRelatedTests: ['src/app/foo.ts'],
-      coverage: false,
-    } as any);
-    expect(argv).toContain('--watch');
-    expect(argv).toContain('--findRelatedTests');
-    // Positional arg must come after --findRelatedTests flag, at the end
-    const frtIdx = argv.indexOf('--findRelatedTests');
-    const fileIdx = argv.indexOf('src/app/foo.ts');
-    expect(fileIdx).toBeGreaterThan(frtIdx);
-    expect(argv[argv.length - 1]).toBe('src/app/foo.ts');
+    it('Should handle a single file path string', () => {
+      const argv = optionsConverter.convertToCliArgs({
+        findRelatedTests: 'src/app/foo.ts',
+      } as any);
+      expect(argv).toEqual(['--findRelatedTests', 'src/app/foo.ts']);
+    });
+
+    it('Should handle array value (e.g. from angular.json)', () => {
+      const argv = optionsConverter.convertToCliArgs({
+        findRelatedTests: ['src/app/foo.ts', 'src/app/bar.ts'],
+      } as any);
+      expect(argv).toEqual(['--findRelatedTests', 'src/app/foo.ts', 'src/app/bar.ts']);
+    });
+
+    it('Should place positional file args at the end, after other flags', () => {
+      const argv = optionsConverter.convertToCliArgs({
+        watch: true,
+        findRelatedTests: 'src/app/foo.ts,src/app/bar.ts',
+      } as any);
+      expect(argv).toContain('--watch');
+      expect(argv).toContain('--findRelatedTests');
+      const frtIdx = argv.indexOf('--findRelatedTests');
+      const fileIdx = argv.indexOf('src/app/foo.ts');
+      expect(fileIdx).toBeGreaterThan(frtIdx);
+      expect(argv[argv.length - 2]).toBe('src/app/foo.ts');
+      expect(argv[argv.length - 1]).toBe('src/app/bar.ts');
+    });
   });
 });

--- a/packages/jest/src/options-converter.ts
+++ b/packages/jest/src/options-converter.ts
@@ -1,9 +1,18 @@
 import { SchemaObject as JestBuilderSchema } from './schema';
 
+/**
+ * Options whose values are positional arguments following a boolean flag.
+ * Jest parses these via yargs `_` (non-flag args), not as repeated --flag value pairs.
+ * See: https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles
+ */
+const POSITIONAL_ARRAY_OPTIONS = new Set(['findRelatedTests']);
+
 export class OptionsConverter {
   convertToCliArgs(options: Partial<JestBuilderSchema>): string[] {
     const argv = [];
     let nonFlagArgs: string | undefined;
+    const positionalArgs: string[] = [];
+
     for (const option of Object.keys(options)) {
       let optionValue = options[option];
       if (option == '--') {
@@ -13,13 +22,23 @@ export class OptionsConverter {
       } else if (typeof optionValue === 'string' || typeof optionValue === 'number') {
         argv.push(`--${option}=${optionValue}`);
       } else if (Array.isArray(optionValue)) {
-        for (const item of optionValue) {
-          argv.push(`--${option}`, item);
+        if (POSITIONAL_ARRAY_OPTIONS.has(option)) {
+          // These are boolean flags whose "values" are positional file args.
+          // e.g. --findRelatedTests file1 file2 (not --findRelatedTests=file1 --findRelatedTests=file2)
+          argv.push(`--${option}`);
+          positionalArgs.push(...optionValue);
+        } else {
+          for (const item of optionValue) {
+            argv.push(`--${option}`, item);
+          }
         }
       }
     }
     if (nonFlagArgs) {
       argv.push(nonFlagArgs);
+    }
+    if (positionalArgs.length > 0) {
+      argv.push(...positionalArgs);
     }
     return argv;
   }

--- a/packages/jest/src/options-converter.ts
+++ b/packages/jest/src/options-converter.ts
@@ -1,8 +1,14 @@
 import { SchemaObject as JestBuilderSchema } from './schema';
 
 /**
- * Options whose values are positional arguments following a boolean flag.
- * Jest parses these via yargs `_` (non-flag args), not as repeated --flag value pairs.
+ * Options that Jest treats as a boolean flag with file paths as positional arguments.
+ * Jest parses these via yargs `_` (non-flag args), not as `--flag=value` or repeated flag pairs.
+ *
+ * Angular CLI passes comma-separated CLI values as a single string for array-type schema fields
+ * (e.g. `ng test --find-related-tests file1,file2` → options.findRelatedTests = 'file1,file2').
+ *
+ * These must be split and emitted as: `--findRelatedTests file1 file2`
+ *
  * See: https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles
  */
 const POSITIONAL_ARRAY_OPTIONS = new Set(['findRelatedTests']);
@@ -17,20 +23,21 @@ export class OptionsConverter {
       let optionValue = options[option];
       if (option == '--') {
         nonFlagArgs = (optionValue as string[]).join(' ');
+      } else if (POSITIONAL_ARRAY_OPTIONS.has(option)) {
+        // Angular CLI passes comma-separated values as a single string for array-type schema fields.
+        // Split into individual paths and emit as: --flag path1 path2 (boolean + positional args).
+        const paths = Array.isArray(optionValue)
+          ? (optionValue as string[])
+          : (optionValue as string).split(',');
+        argv.push(`--${option}`);
+        positionalArgs.push(...paths);
       } else if (optionValue === true) {
         argv.push(`--${option}`);
       } else if (typeof optionValue === 'string' || typeof optionValue === 'number') {
         argv.push(`--${option}=${optionValue}`);
       } else if (Array.isArray(optionValue)) {
-        if (POSITIONAL_ARRAY_OPTIONS.has(option)) {
-          // These are boolean flags whose "values" are positional file args.
-          // e.g. --findRelatedTests file1 file2 (not --findRelatedTests=file1 --findRelatedTests=file2)
-          argv.push(`--${option}`);
-          positionalArgs.push(...optionValue);
-        } else {
-          for (const item of optionValue) {
-            argv.push(`--${option}`, item);
-          }
+        for (const item of optionValue) {
+          argv.push(`--${option}`, item);
         }
       }
     }


### PR DESCRIPTION
## Problem

Fixes #2150

### Root cause

Angular CLI passes comma-separated CLI values as a **single string** for `array`-type schema fields. So:

```sh
ng test --find-related-tests file1,file2
```

...arrives at `OptionsConverter` as `options.findRelatedTests = 'file1,file2'` (a string, not an array).

The existing string branch then emits:

```
--findRelatedTests=file1,file2
```

But Jest declares `--findRelatedTests` as a **boolean** yargs option. When yargs sees `--findRelatedTests=file1,file2` for a boolean option, it coerces the value → `false`, and no positional file paths land in `argv._`. Result: `Pattern: file1,file2 - 0 matches`.

### Why is this only surfacing now?

This was always broken — it just wasn't widely reported. The feature has been available since the original `find-related-tests` schema addition (2019), and the README even documents the comma-separated syntax as the correct way to pass multiple files. The bug affects anyone trying to use it.

## Fix

Introduce `POSITIONAL_ARRAY_OPTIONS` — a set of option names that Jest treats as a boolean flag with file paths as trailing positional arguments (parsed via yargs `_`). For these options, the converter:

1. Splits the comma-separated string into individual paths
2. Emits the boolean flag once: `--findRelatedTests`
3. Appends the paths as positional args at the end of `argv`

Result for `ng test --find-related-tests file1,file2`:

```
--findRelatedTests file1 file2
```

Jest yargs parsing: `findRelatedTests=true`, `_=['file1', 'file2']` ✅

Also handles array values (e.g. from `angular.json`) for the same options.

## Tests

Added four unit tests to `options-converter.spec.ts` covering:
- Comma-separated string (the Angular CLI case)
- Single file path string
- Array value (from `angular.json`)
- Correct positioning of positional args after other flags