### PR TITLE
fix(jest): handle comma-separated paths in findRelatedTests

### DIFF
--- a/packages/jest/src/options-converter.ts
+++ b/packages/jest/src/options-converter.ts
@@ -1,13 +1,35 @@
 import { SchemaObject as JestBuilderSchema } from './schema';
 
+/**
+ * Options that Jest treats as a boolean flag with file paths as trailing positional
+ * arguments (parsed via yargs `_`). For these options the converter emits the flag
+ * once and appends every path as a bare positional at the end of argv.
+ *
+ * Example: `--findRelatedTests file1.ts file2.ts`
+ * Jest yargs parsing: `findRelatedTests=true`, `_=['file1.ts', 'file2.ts']`
+ */
+const POSITIONAL_ARRAY_OPTIONS = new Set(['findRelatedTests']);
+
 export class OptionsConverter {
   convertToCliArgs(options: Partial<JestBuilderSchema>): string[] {
     const argv = [];
+    const positionalArgs: string[] = [];
     let nonFlagArgs: string | undefined;
+
     for (const option of Object.keys(options)) {
-      let optionValue = options[option];
-      if (option == '--') {
+      const optionValue = options[option];
+
+      if (option === '--') {
         nonFlagArgs = (optionValue as string[]).join(' ');
+      } else if (POSITIONAL_ARRAY_OPTIONS.has(option)) {
+        // Normalise: Angular CLI may deliver a single comma-joined string (when the
+        // value is set inline in angular.json or passed as --flag=a,b on the CLI)
+        // or a proper array (when passed as space-separated args on the CLI).
+        const paths = Array.isArray(optionValue)
+          ? (optionValue as string[]).flatMap(v => v.split(','))
+          : (optionValue as string).split(',');
+        argv.push(`--${option}`);
+        positionalArgs.push(...paths);
       } else if (optionValue === true) {
         argv.push(`--${option}`);
       } else if (typeof optionValue === 'string' || typeof optionValue === 'number') {
@@ -18,9 +40,11 @@ export class OptionsConverter {
         }
       }
     }
+
     if (nonFlagArgs) {
       argv.push(nonFlagArgs);
     }
-    return argv;
+
+    return [...argv, ...positionalArgs];
   }
 }

--- a/packages/jest/tests/integration.js
+++ b/packages/jest/tests/integration.js
@@ -106,6 +106,15 @@ module.exports = [
     command:
       'node ../../../packages/jest/tests/validate.js my-shared-library --find-related-tests projects/my-shared-library/src/lib/my-shared-library.service.ts projects/my-shared-library/src/lib/my-shared-library.component.ts --expect-suites=2 --expect-tests=2',
   },
+  {
+    id: 'multi-project-find-related-comma',
+    name: 'jest: --find-related-tests comma-separated',
+    purpose: '--find-related-tests with comma-separated files (inline angular.json value) finds related tests',
+    app: 'examples/jest/multiple-apps',
+    command:
+      'node ../../../packages/jest/tests/validate.js my-shared-library "--find-related-tests=projects/my-shared-library/src/lib/my-shared-library.service.ts,projects/my-shared-library/src/lib/my-shared-library.component.ts" --expect-suites=2 --expect-tests=2',
+  },
+
 
   // E2E sanity
   {


### PR DESCRIPTION
## Problem

Fixes #2150

### Root cause

Angular CLI delivers `--find-related-tests=a,b` (comma-separated, e.g. set via `angular.json` or as `--flag=a,b` on the CLI) as a **single-element array** containing the comma-joined string: `["a,b"]`.

The existing `Array.isArray` branch iterated the array and emitted:

```
--findRelatedTests a,b
```

Jest receives `a,b` as a **single positional** and tries to match it as a file path — finds nothing:

```
Pattern: a,b - 0 matches
No tests found, exiting with code 1
```

### Fix

Introduce `POSITIONAL_ARRAY_OPTIONS` — a set of option names that Jest treats as a boolean flag with file paths as trailing positional args. For these options the converter:

1. Splits any comma-joined string into individual paths
2. Emits the boolean flag once: `--findRelatedTests`
3. Appends all paths as positionals at the end of `argv`

Result for `--find-related-tests=a.ts,b.ts`:

```
--findRelatedTests a.ts b.ts
```

Jest yargs: `findRelatedTests=true`, `_=["a.ts", "b.ts"]` ✅

The existing space-separated multi-file behaviour is preserved — Angular CLI delivers a proper array in that case, each element is a single path (no comma-splitting needed, but the flatMap handles it safely).

## Tests

Added integration test `multi-project-find-related-comma` that:
- **Fails on master** (`Pattern: ... - 0 matches`, exit 1)
- **Passes after this fix** (2 suites, 2 tests found)

The existing `multi-project-find-related` test (space-separated, two files) continues to pass.