### PR TITLE
docs(jest): warn about projects field conflict with builder orchestration

### DIFF
--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -107,6 +107,29 @@ The builder supports multi-project workspaces out of the box, the only thing req
   3.  Add on top of it _package.json_ jest config if exists (for **all** projects)
       **or**
       _jest.config.js_ from workspace root directory if exists
+
+      > **⚠️ Note on the `projects` field:** The builder acts as the Jest orchestrator via Angular CLI's project system. If your root `jest.config.js` (or `package.json` jest config) contains a `projects` field (used for running Jest standalone across a monorepo), the builder will merge it in and Jest will run **all** sub-projects instead of just the targeted Angular project — resulting in duplicated or unexpected test runs.
+      >
+      > If you use both `ng test` (via the builder) and `jest` directly (standalone), keep the `projects` field out of the root config and use a separate config file for standalone runs:
+      >
+      > **`jest.config.js`** — used by the Angular builder (no `projects` field):
+      > ```js
+      > module.exports = {
+      >   // shared options: transform, moduleNameMapper, coverageThreshold, etc.
+      > };
+      > ```
+      >
+      > **`jest.projects.config.js`** — used for standalone Jest CLI runs:
+      > ```js
+      > const baseConfig = require('./jest.config');
+      > module.exports = {
+      >   ...baseConfig,
+      >   projects: ['<rootDir>/apps/*', '<rootDir>/libs/*'],
+      > };
+      > ```
+      >
+      > Then run standalone Jest with `jest --config jest.projects.config.js`.
+
   4.  Add on top of it project specific config if it is specified inside _angular.json_
       **or**
       _jest.config.js_ from project directory (or src/ directory in case of non-project app) if exists.


### PR DESCRIPTION
## Summary

Adds a warning note in the Jest builder README under the configuration merge section (step 3 — global config layer) explaining that a `projects` field in the root `jest.config.js` or `package.json` jest config will conflict with the builder's own project orchestration.

## Why

The builder acts as the Jest orchestrator via Angular CLI's project system. When `projects` is present in the globally merged config, Jest runs all sub-projects instead of just the targeted Angular project — causing duplicated or unexpected test runs. This is by design (the builder takes over orchestration), but it wasn't documented, leading to confusion (see #1910).

## What changed

- Added a `⚠️ Note` callout under step 3 of the configuration merge description in `packages/jest/README.md`
- Explains the conflict clearly
- Provides a concrete workaround: use `jest.config.js` (no `projects`) for the builder, and a separate `jest.projects.config.js` that extends the base config and adds `projects` for standalone Jest CLI usage

Closes #1910