### PR TITLE
fix(custom-webpack): preserve anonymous plain-object plugins during merge

### DIFF
--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -383,6 +383,37 @@ module.exports = {
 Keep in mind though that if there are default values in the plugin's constructor, they would override the corresponding values in the existing instance. So these you have to set explicitly to the same values Angular sets.  
 You can check out an example for plugins merge in the [unit tests](./src/webpack-config-merger.spec.ts) and in [this](https://github.com/just-jeb/angular-builders/issues/13) issue.
 
+> **⚠️ Plugin identification and anonymous plugins**
+>
+> The builder identifies plugins by their **constructor name** (`plugin.constructor.name`) to decide whether two plugins are the "same" and should be merged or replaced.
+> This means:
+>
+> - **Named class plugins** (e.g., `new DefinePlugin(...)`, `new CircularDependencyPlugin(...)`) are identified correctly and participate in merge/replace logic as expected.
+> - **Plain object plugins** (e.g., `{ apply(compiler) { ... } }`) have `constructor.name === 'Object'` and are therefore **indistinguishable from each other**. The builder cannot tell one anonymous plugin from another, so it treats them all as the same plugin type.
+>
+> If you add a plain-object plugin in your custom config, it will **not** be deduplicated or merged with other plain-object plugins — all anonymous plugins (yours and Angular's) are preserved as-is.
+>
+> If you want your plugin to participate in merge or replace logic (e.g., override an existing plugin of the same kind), give it a named constructor:
+>
+> ```js
+> // ✅ Named — participates in deduplication and merge
+> class MyPlugin {
+>   apply(compiler) { ... }
+> }
+> module.exports = { plugins: [new MyPlugin()] };
+>
+> // ✅ Also named — constructor.name is 'MyPlugin'
+> function MyPlugin() {}
+> MyPlugin.prototype.apply = function(compiler) { ... };
+> module.exports = { plugins: [new MyPlugin()] };
+>
+> // ❌ Anonymous — constructor.name is 'Object', cannot be deduplicated or merged
+> module.exports = { plugins: [{ apply(compiler) { ... } }] };
+> ```
+>
+> For full control over the merge, use a [function export](#custom-webpack-config-function) — you receive the full base config and return a new one, bypassing automatic merge entirely.
+
+
 ## Custom Webpack Promisified Config
 
 Webpack config can also export a `Promise` object that resolves custom config. Given the following example:

--- a/packages/custom-webpack/src/webpack-config-merger.spec.ts
+++ b/packages/custom-webpack/src/webpack-config-merger.spec.ts
@@ -361,4 +361,83 @@ describe('Webpack config merger test', () => {
 
     expect(mergeConfigs(conf1, conf2)).toEqual(expected);
   });
+
+  describe('Anonymous plain-object plugin handling', () => {
+    it('should preserve anonymous base plugins when user config has a plain-object plugin', () => {
+      // Regression test for: https://github.com/just-jeb/angular-builders/issues/1908
+      //
+      // Angular CLI injects anonymous plain-object plugins (e.g. the i18n hash-update
+      // plugin added in angular/angular-cli#16817) into the base webpack config.
+      // These plugins have constructor.name === 'Object' and MUST NOT be treated as
+      // duplicates of user-supplied plain-object plugins. Previously, any user
+      // plain-object plugin would cause Angular's anonymous plugins to be silently
+      // dropped or overwritten, breaking localized build hash regeneration.
+
+      let i18nHookCalled = false;
+      const angularI18nPlugin = {
+        apply(_compiler: any) {
+          i18nHookCalled = true;
+        },
+      };
+
+      let userHookCalled = false;
+      const userPlugin = {
+        apply(_compiler: any) {
+          userHookCalled = true;
+        },
+      };
+
+      const output = mergeConfigs(
+        { plugins: [angularI18nPlugin] },
+        { plugins: [userPlugin] }
+      );
+
+      expect(output.plugins).toHaveLength(2);
+      // Both anonymous plugins must survive and be callable
+      output.plugins!.forEach(p => (p as any).apply(null));
+      expect(i18nHookCalled).toBe(true);
+      expect(userHookCalled).toBe(true);
+    });
+
+    it('should keep anonymous base plugins before named plugins in merged output', () => {
+      const anonymousPlugin = { apply(_compiler: any) {} };
+      const namedPlugin = new webpack.DefinePlugin({ FOO: '"bar"' });
+
+      const output = mergeConfigs(
+        { plugins: [anonymousPlugin, namedPlugin] },
+        { plugins: [] }
+      );
+
+      expect(output.plugins).toHaveLength(2);
+      expect(output.plugins![0]).toBe(anonymousPlugin);
+      expect(output.plugins![1]).toBeInstanceOf(webpack.DefinePlugin);
+    });
+
+    it('should not deduplicate two anonymous plain-object plugins', () => {
+      const anonPlugin1 = { apply(_compiler: any) {} };
+      const anonPlugin2 = { apply(_compiler: any) {} };
+
+      const output = mergeConfigs(
+        { plugins: [anonPlugin1] },
+        { plugins: [anonPlugin2] }
+      );
+
+      // Both plain-object plugins must survive — neither is a duplicate of the other
+      expect(output.plugins).toHaveLength(2);
+    });
+
+    it('should still deduplicate named class-based plugins as before', () => {
+      const basePlugin = new webpack.HotModuleReplacementPlugin({ multiStep: true, requestTimeout: 1000 });
+      const userPlugin = new webpack.HotModuleReplacementPlugin({ requestTimeout: 500 });
+
+      const output = mergeConfigs(
+        { plugins: [basePlugin] },
+        { plugins: [userPlugin] }
+      );
+
+      // Named class plugins are still deduplicated (merged)
+      expect(output.plugins).toHaveLength(1);
+      expect(output.plugins![0]).toBeInstanceOf(webpack.HotModuleReplacementPlugin);
+    });
+  });
 });

--- a/packages/custom-webpack/src/webpack-config-merger.ts
+++ b/packages/custom-webpack/src/webpack-config-merger.ts
@@ -15,6 +15,28 @@ const DEFAULT_MERGE_RULES: MergeRules = {
   },
 };
 
+/**
+ * Returns true if a plugin has a meaningful, unique class name that can be used
+ * as a deduplication key. Plain object plugins (constructor.name === 'Object')
+ * cannot be reliably identified as duplicates of another plugin, so they must
+ * never be merged or deduplicated against other plugins.
+ *
+ * Concretely, Angular CLI injects anonymous plain-object plugins (e.g. the i18n
+ * hash-update plugin added in angular/angular-cli#16817) into the base webpack
+ * config. If those were matched against a user's plain-object plugin, the Angular
+ * plugin would be silently dropped or corrupted, breaking features like localized
+ * build hash regeneration.
+ */
+function isNamedPlugin(plugin: any): boolean {
+  return (
+    plugin != null &&
+    typeof plugin.constructor === 'function' &&
+    typeof plugin.constructor.name === 'string' &&
+    plugin.constructor.name !== '' &&
+    plugin.constructor.name !== 'Object'
+  );
+}
+
 export function mergeConfigs(
   webpackConfig1: Configuration,
   webpackConfig2: Configuration,
@@ -24,18 +46,27 @@ export function mergeConfigs(
   const mergedConfig: Configuration = mergeWithRules(mergeRules)(webpackConfig1, webpackConfig2);
 
   if (webpackConfig1.plugins && webpackConfig2.plugins) {
-    const conf1ExceptConf2 = differenceWith(
-      webpackConfig1.plugins,
+    // Only named (class-based) plugins from conf1 participate in deduplication.
+    // Anonymous plain-object plugins (constructor.name === 'Object') are always
+    // treated as unique and prepended as-is — they cannot be identified as
+    // duplicates of user plugins.
+    const namedConf1Plugins = webpackConfig1.plugins.filter(isNamedPlugin);
+    const anonymousConf1Plugins = webpackConfig1.plugins.filter(p => !isNamedPlugin(p));
+
+    const namedConf1ExceptConf2 = differenceWith(
+      namedConf1Plugins,
       webpackConfig2.plugins,
       (item1, item2) => item1.constructor.name === item2.constructor.name
     );
     if (!replacePlugins) {
-      const conf1ByName = keyBy(webpackConfig1.plugins, 'constructor.name');
+      const conf1ByName = keyBy(namedConf1Plugins, 'constructor.name');
       webpackConfig2.plugins = webpackConfig2.plugins.map(p =>
-        conf1ByName[p.constructor.name] ? merge(conf1ByName[p.constructor.name], p) : p
+        isNamedPlugin(p) && conf1ByName[p.constructor.name]
+          ? merge(conf1ByName[p.constructor.name], p)
+          : p
       );
     }
-    mergedConfig.plugins = [...conf1ExceptConf2, ...webpackConfig2.plugins];
+    mergedConfig.plugins = [...anonymousConf1Plugins, ...namedConf1ExceptConf2, ...webpackConfig2.plugins];
   }
   return mergedConfig;
 }


### PR DESCRIPTION
## Problem

Angular CLI injects anonymous plain-object plugins into the base webpack config — the most prominent example is the i18n hash-update plugin added in [angular/angular-cli#16817](https://github.com/angular/angular-cli/pull/16817), which ensures that changing a translation file causes chunk hashes to update in localized builds.

Because this plugin is a plain object literal (`{ apply(compiler) { ... } }`), its `constructor.name` is `'Object'`. The previous deduplication logic in `mergeConfigs()` used `constructor.name` as the sole identity key. When a user's custom webpack config contained **any** plain-object plugin, `differenceWith()` treated Angular's anonymous plugin as a duplicate and dropped it. The subsequent `lodash.merge()` then overwrote Angular's plugin with the user's — silently removing the i18n hash hook.

Result: translation file changes did **not** cause chunk hashes to update in localized builds when using `@angular-builders/custom-webpack`.

## Root Cause

```ts
// Before fix: ALL plugins matched by constructor.name, so two { apply() {} } objects
// were considered the same plugin — Angular's i18n plugin got dropped.
const conf1ExceptConf2 = differenceWith(
  webpackConfig1.plugins,
  webpackConfig2.plugins,
  (item1, item2) => item1.constructor.name === item2.constructor.name  // 'Object' === 'Object'
);
```

## Fix

Anonymous plugins (`constructor.name === 'Object'`) are excluded from deduplication entirely. They are always prepended to the final plugin array as-is. Only named, class-based plugins (e.g. `HtmlWebpackPlugin`, `HotModuleReplacementPlugin`) participate in the existing merge/replace logic — identical behaviour to before for those cases.

## Tests

Four new unit tests added to `webpack-config-merger.spec.ts`:
- Anonymous base plugin survives when user config has a plain-object plugin (the regression case)
- Anonymous base plugins are ordered before named plugins
- Two anonymous plugins are never deduplicated against each other
- Named class plugins are still deduplicated as before (backward-compat guard)

Closes #1908