### PR TITLE
fix(deps): add rxjs>=7 as peerDependency to custom-esbuild, custom-webpack, and jest (fixes #1863)

### DIFF
--- a/packages/custom-esbuild/package.json
+++ b/packages/custom-esbuild/package.json
@@ -46,6 +46,7 @@
   },
   "peerDependencies": {
     "@angular/compiler-cli": "^21.0.0",
+    "rxjs": ">=7.0.0",
     "vitest": ">=2"
   },
   "devDependencies": {

--- a/packages/custom-webpack/package.json
+++ b/packages/custom-webpack/package.json
@@ -48,7 +48,8 @@
     "webpack-merge": "^6.0.0"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^21.0.0"
+    "@angular/compiler-cli": "^21.0.0",
+    "rxjs": ">=7.0.0"
   },
   "devDependencies": {
     "jest": "30.3.0",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -52,7 +52,8 @@
     "@angular/compiler-cli": "^21.0.0",
     "@angular/core": "^21.0.0",
     "@angular/platform-browser-dynamic": "^21.0.0",
-    "jest": "^30.0.0"
+    "jest": "^30.0.0",
+    "rxjs": ">=7.0.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
Superseded by #2188 — closing this duplicate.