### PR TITLE
fix(common): remove moduleResolution override in ts-node register (fixes #2025)

### DIFF
--- a/examples/custom-webpack/full-cycle-app/angular.json
+++ b/examples/custom-webpack/full-cycle-app/angular.json
@@ -75,6 +75,14 @@
             },
             "itwcw": {
               "indexTransform": "./index-html.transform.ts"
+            },
+            "bundler-resolution-ts": {
+              "customWebpackConfig": {
+                "path": "./extra-webpack.config.bundler.ts",
+                "mergeRules": {
+                  "plugins": "prepend"
+                }
+              }
             }
           }
         },

--- a/examples/custom-webpack/full-cycle-app/extra-webpack.config.bundler.ts
+++ b/examples/custom-webpack/full-cycle-app/extra-webpack.config.bundler.ts
@@ -1,0 +1,11 @@
+import { Configuration } from 'webpack';
+// This subpath export only resolves with moduleResolution:bundler (no physical file at this path).
+// If the builder overrides moduleResolution to 'node', this import fails with TS2307.
+// Regression test for: https://github.com/just-jeb/angular-builders/issues/2025
+// We use an empty type import (`import type {}`) to test pure path resolution without
+// depending on any specific exported member name.
+import type {} from '@angular/core/primitives/di';
+
+export default {
+  plugins: [],
+} as Configuration;

--- a/packages/common/src/load-module.ts
+++ b/packages/common/src/load-module.ts
@@ -22,9 +22,16 @@ const _tsNodeRegister = (() => {
       project: tsConfig,
       compilerOptions: {
         module: 'CommonJS',
-        moduleResolution: 'node',
+        // We deliberately do NOT override moduleResolution here.
+        // The user's tsconfig moduleResolution setting (node, bundler, node16, etc.) is preserved.
+        // TypeScript allows moduleResolution:bundler with module:CommonJS, so type checking
+        // works correctly for all moduleResolution values — including 'bundler', which supports
+        // subpath package exports (e.g. '@angular/core/primitives/di').
+        // Overriding moduleResolution to 'node' (as was done previously) was the root cause of
+        // issue https://github.com/just-jeb/angular-builders/issues/2025: it prevented TypeScript
+        // from resolving subpath exports, causing TS2307 errors at build time.
         types: [
-          'node', // NOTE: `node` is added because users scripts can also use pure node's packages as webpack or others
+          'node', // NOTE: `node` is added so user configs can use Node.js globals (process, __dirname, etc.)
         ],
       },
     });
@@ -45,7 +52,6 @@ const _tsNodeRegister = (() => {
 /**
  * check for TS node registration
  * @param file: file name or file directory are allowed
- * @todo tsNodeRegistration: require ts-node if file extension is TypeScript
  */
 function tsNodeRegister(file: string = '', tsConfig: string, logger: logging.LoggerApi) {
   if (file?.endsWith('.ts')) {
@@ -90,7 +96,7 @@ export async function loadModule<T>(
       return require(modulePath);
     case '.ts':
       try {
-        // If it's a TS file then there are 2 cases for exporing an object.
+        // If it's a TS file then there are 2 cases for exporting an object.
         // The first one is `export blah`, transpiled into `module.exports = { blah} `.
         // The second is `export default blah`, transpiled into `{ default: { ... } }`.
         return require(modulePath).default || require(modulePath);

--- a/packages/custom-webpack/src/transform-factories.spec.ts
+++ b/packages/custom-webpack/src/transform-factories.spec.ts
@@ -32,6 +32,13 @@ describe('getTransforms', () => {
     transforms.webpackConfiguration({});
 
     expect(tsNode.register).toHaveBeenCalledTimes(1);
+    expect(tsNode.register).toHaveBeenCalledWith({
+      project: 'test/tsconfig.test.json',
+      compilerOptions: {
+        module: 'CommonJS',
+        types: ['node'],
+      },
+    });
     expect(logger.warn).not.toHaveBeenCalled();
 
     const transforms2 = getTransforms(

--- a/packages/custom-webpack/tests/integration.js
+++ b/packages/custom-webpack/tests/integration.js
@@ -97,4 +97,11 @@ module.exports = [
     app: 'examples/custom-webpack/sanity-app-esm',
     command: 'yarn build-ts -c tsEsm',
   },
+  {
+    id: 'ts-config-bundler-module-resolution',
+    name: 'custom-webpack: TS config with moduleResolution:bundler imports',
+    purpose: 'Builder loads TypeScript webpack config that uses subpath exports requiring moduleResolution:bundler (regression for #2025)',
+    app: 'examples/custom-webpack/full-cycle-app',
+    command: 'yarn build -c bundler-resolution-ts',
+  },
 ];


### PR DESCRIPTION
## Problem

When a user sets `moduleResolution: "bundler"` in their `tsconfig.json`, the custom-webpack builder was silently overriding it with `"node"` inside `ts-node`'s `register()` call. This caused TypeScript to fail resolving packages that are only accessible via the `package.json` `exports` field (subpath exports), producing `TS2307: Cannot find module` errors.

Example: `@angular/core/primitives/di` has no physical file on disk — it is only accessible via the `exports` field. With `moduleResolution: "bundler"` it resolves fine; with `"node"` it does not.

Reported in #2025.

## Root Cause

In `packages/common/src/load-module.ts`, `_tsNodeRegister()` passes `compilerOptions.moduleResolution: 'node'` to `ts-node`. This overrides whatever the user set in their `tsconfig.json`, regardless of their intent.

```ts
// Before (buggy)
loadTsNode().register({
  project: tsConfig,
  compilerOptions: {
    module: 'CommonJS',
    moduleResolution: 'node',  // <-- BUG: forces node resolution, ignoring user's tsconfig
    types: ['node'],
  },
});
```

## Fix

Remove the `moduleResolution` override entirely. TypeScript explicitly allows `moduleResolution: "bundler"` together with `module: "CommonJS"` — the combination type-checks using bundler resolution semantics (respects `exports` field) while emitting CommonJS output for the Node.js process.

```ts
// After (fixed)
loadTsNode().register({
  project: tsConfig,
  compilerOptions: {
    module: 'CommonJS',   // kept — Angular CLI runs in a CJS process
    // moduleResolution not set — user's tsconfig value is preserved
    types: ['node'],     // kept — gives webpack configs access to Node globals
  },
});
```

## Regression Test

Adds a new `bundler-resolution-ts` angular.json configuration in `full-cycle-app` that uses a TypeScript webpack config importing from `@angular/core/primitives/di` (a subpath export, no physical file). The integration test `ts-config-bundler-module-resolution` in `integration.js` verifies that `ng build -c bundler-resolution-ts` succeeds. This fails before the fix and passes after.

## Previously attempted

An earlier iteration replaced `ts-node` with `tsx`. This was reverted because `tsx` uses esbuild for transpilation and skips TypeScript's type checker entirely — a regression for users who choose `.ts` config files specifically for type safety.

Fixes #2025