### PR TITLE
fix(deps): add rxjs>=7 as peer dependency to custom-esbuild, custom-webpack, and jest (fixes #1863)

### DIFF
--- a/packages/custom-esbuild/package.json
+++ b/packages/custom-esbuild/package.json
@@ -46,6 +46,7 @@
   },
   "peerDependencies": {
     "@angular/compiler-cli": "^21.0.0",
+    "rxjs": ">=7.0.0",
     "vitest": ">=2"
   },
   "devDependencies": {

--- a/packages/custom-webpack/package.json
+++ b/packages/custom-webpack/package.json
@@ -48,7 +48,8 @@
     "webpack-merge": "^6.0.0"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^21.0.0"
+    "@angular/compiler-cli": "^21.0.0",
+    "rxjs": ">=7.0.0"
   },
   "devDependencies": {
     "jest": "30.3.0",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -52,7 +52,8 @@
     "@angular/compiler-cli": "^21.0.0",
     "@angular/core": "^21.0.0",
     "@angular/platform-browser-dynamic": "^21.0.0",
-    "jest": "^30.0.0"
+    "jest": "^30.0.0",
+    "rxjs": ">=7.0.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,6 +218,7 @@ __metadata:
     typescript: 5.9.3
   peerDependencies:
     "@angular/compiler-cli": ^21.0.0
+    rxjs: ">=7.0.0"
     vitest: ">=2"
   languageName: unknown
   linkType: soft
@@ -239,6 +240,7 @@ __metadata:
     webpack-merge: ^6.0.0
   peerDependencies:
     "@angular/compiler-cli": ^21.0.0
+    rxjs: ">=7.0.0"
   languageName: unknown
   linkType: soft
 
@@ -263,6 +265,7 @@ __metadata:
     "@angular/core": ^21.0.0
     "@angular/platform-browser-dynamic": ^21.0.0
     jest: ^30.0.0
+    rxjs: ">=7.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Problem

All three packages (`custom-esbuild`, `custom-webpack`, `jest`) import directly from `rxjs` (e.g. `switchMap`, `defer`, `from`, `Observable`) but none declared it as a peer dependency.

This caused runtime errors when a consumer project had `rxjs@6` installed — the v6 package would shadow the v7 brought in transitively by `@angular-devkit/architect`, leading to subtle incompatibilities.

## Fix

Add `"rxjs": ">=7.0.0"` to `peerDependencies` in each affected package. This makes the dependency contract explicit and surfaces version mismatches to the consumer at install time.

Fixes #1863