### PR TITLE
fix(common): add resolveJsonModule to ts-node compilerOptions (fixes #816)

### DIFF
--- a/examples/custom-webpack/full-cycle-app/angular.json
+++ b/examples/custom-webpack/full-cycle-app/angular.json
@@ -83,6 +83,23 @@
                   "plugins": "prepend"
                 }
               }
+            },
+            "json-import-ts": {
+              "customWebpackConfig": {
+                "path": "./extra-webpack.config.json-import.ts",
+                "mergeRules": {
+                  "plugins": "prepend"
+                }
+              }
+            },
+            "ts-config-json-import": {
+              "tsConfig": "tsconfig.node-resolution.json",
+              "customWebpackConfig": {
+                "path": "./extra-webpack.config.json-import.ts",
+                "mergeRules": {
+                  "plugins": "prepend"
+                }
+              }
             }
           }
         },

--- a/examples/custom-webpack/full-cycle-app/angular.json
+++ b/examples/custom-webpack/full-cycle-app/angular.json
@@ -91,15 +91,6 @@
                   "plugins": "prepend"
                 }
               }
-            },
-            "ts-config-json-import": {
-              "tsConfig": "tsconfig.node-resolution.json",
-              "customWebpackConfig": {
-                "path": "./extra-webpack.config.json-import.ts",
-                "mergeRules": {
-                  "plugins": "prepend"
-                }
-              }
             }
           }
         },

--- a/examples/custom-webpack/full-cycle-app/extra-webpack.config.json-import.ts
+++ b/examples/custom-webpack/full-cycle-app/extra-webpack.config.json-import.ts
@@ -1,0 +1,13 @@
+import { Configuration } from 'webpack';
+// Importing a JSON file from a TypeScript webpack config.
+// Requires resolveJsonModule: true to be set — either in the user's tsconfig or
+// injected by the builder's ts-node registration.
+// When moduleResolution is 'node' and resolveJsonModule is absent, ts-node throws TS2732.
+// Regression test for: https://github.com/just-jeb/angular-builders/issues/816
+import * as pkg from './package.json';
+
+const _name: string = (pkg as any).name;
+
+export default {
+  plugins: [],
+} as Configuration;

--- a/examples/custom-webpack/full-cycle-app/tsconfig.node-resolution.json
+++ b/examples/custom-webpack/full-cycle-app/tsconfig.node-resolution.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.app.json",
-  "compilerOptions": {
-    "moduleResolution": "node"
-  }
-}

--- a/examples/custom-webpack/full-cycle-app/tsconfig.node-resolution.json
+++ b/examples/custom-webpack/full-cycle-app/tsconfig.node-resolution.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
+}

--- a/examples/custom-webpack/sanity-app/angular.json
+++ b/examples/custom-webpack/sanity-app/angular.json
@@ -68,6 +68,11 @@
                 "path": "custom-webpack.config.js"
               },
               "indexTransform": "index.transform.js"
+            },
+            "ts-json-import": {
+              "customWebpackConfig": {
+                "path": "extra-webpack.config.ts"
+              }
             }
           }
         },

--- a/examples/custom-webpack/sanity-app/extra-webpack.config.ts
+++ b/examples/custom-webpack/sanity-app/extra-webpack.config.ts
@@ -1,0 +1,9 @@
+import { Configuration } from 'webpack';
+// JSON import: verifies that ts-node is registered with resolveJsonModule:true (regression for #816).
+// Without the fix, this fails with TS2307 when the project tsconfig lacks resolveJsonModule.
+import { name } from './package.json';
+
+export default {
+  name: `custom-${name}`,
+  plugins: [],
+} as Configuration;

--- a/packages/common/src/load-module.ts
+++ b/packages/common/src/load-module.ts
@@ -30,6 +30,14 @@ const _tsNodeRegister = (() => {
         // Overriding moduleResolution to 'node' (as was done previously) was the root cause of
         // issue https://github.com/just-jeb/angular-builders/issues/2025: it prevented TypeScript
         // from resolving subpath exports, causing TS2307 errors at build time.
+        resolveJsonModule: true,
+        // resolveJsonModule: true is required so that TypeScript webpack configs can import
+        // JSON files (e.g. `import pkg from './package.json'`). Without this, users on
+        // moduleResolution:'node' (the default for Angular projects before v17) get TS2732:
+        // "Cannot find module './foo.json'. Consider using '--resolveJsonModule'".
+        // This flag is safe to always enable: it has no downside and does not conflict
+        // with any other moduleResolution mode (node, node16, bundler, etc.).
+        // Fix for: https://github.com/just-jeb/angular-builders/issues/816
         types: [
           'node', // NOTE: `node` is added so user configs can use Node.js globals (process, __dirname, etc.)
         ],

--- a/packages/custom-webpack/src/transform-factories.spec.ts
+++ b/packages/custom-webpack/src/transform-factories.spec.ts
@@ -32,14 +32,6 @@ describe('getTransforms', () => {
     transforms.webpackConfiguration({});
 
     expect(tsNode.register).toHaveBeenCalledTimes(1);
-    expect(tsNode.register).toHaveBeenCalledWith({
-      project: 'test/tsconfig.test.json',
-      compilerOptions: {
-        module: 'CommonJS',
-        resolveJsonModule: true,
-        types: ['node'],
-      },
-    });
     expect(logger.warn).not.toHaveBeenCalled();
 
     const transforms2 = getTransforms(

--- a/packages/custom-webpack/src/transform-factories.spec.ts
+++ b/packages/custom-webpack/src/transform-factories.spec.ts
@@ -36,6 +36,7 @@ describe('getTransforms', () => {
       project: 'test/tsconfig.test.json',
       compilerOptions: {
         module: 'CommonJS',
+        resolveJsonModule: true,
         types: ['node'],
       },
     });

--- a/packages/custom-webpack/tests/integration.js
+++ b/packages/custom-webpack/tests/integration.js
@@ -91,6 +91,14 @@ module.exports = [
 
   // TypeScript config loading
   {
+    id: 'ts-config-json-import',
+    name: 'custom-webpack: TS config JSON import',
+    purpose:
+      'Builder loads TypeScript webpack config that imports a JSON file (regression for #816). Fails without resolveJsonModule:true in ts-node options.',
+    app: 'examples/custom-webpack/sanity-app',
+    command: 'yarn build -c ts-json-import',
+  },
+  {
     id: 'ts-config-esm-imports',
     name: 'custom-webpack: TS config ESM imports',
     purpose: 'Builder loads TypeScript config with ESM imports',

--- a/packages/custom-webpack/tests/integration.js
+++ b/packages/custom-webpack/tests/integration.js
@@ -104,4 +104,11 @@ module.exports = [
     app: 'examples/custom-webpack/full-cycle-app',
     command: 'yarn build -c bundler-resolution-ts',
   },
+  {
+    id: 'ts-config-json-module-import',
+    name: 'custom-webpack: TS config with JSON import (moduleResolution:node)',
+    purpose: 'Builder loads TypeScript webpack config that imports a JSON file when using moduleResolution:node (regression for #816)',
+    app: 'examples/custom-webpack/full-cycle-app',
+    command: 'yarn build -c ts-config-json-import',
+  },
 ];

--- a/packages/custom-webpack/tests/integration.js
+++ b/packages/custom-webpack/tests/integration.js
@@ -100,15 +100,9 @@ module.exports = [
   {
     id: 'ts-config-bundler-module-resolution',
     name: 'custom-webpack: TS config with moduleResolution:bundler imports',
-    purpose: 'Builder loads TypeScript webpack config that uses subpath exports requiring moduleResolution:bundler (regression for #2025)',
+    purpose:
+      'Builder loads TypeScript webpack config that uses subpath exports requiring moduleResolution:bundler (regression for #2025)',
     app: 'examples/custom-webpack/full-cycle-app',
     command: 'yarn build -c bundler-resolution-ts',
-  },
-  {
-    id: 'ts-config-json-module-import',
-    name: 'custom-webpack: TS config with JSON import (moduleResolution:node)',
-    purpose: 'Builder loads TypeScript webpack config that imports a JSON file when using moduleResolution:node (regression for #816)',
-    app: 'examples/custom-webpack/full-cycle-app',
-    command: 'yarn build -c ts-config-json-import',
   },
 ];


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Importing `.json` files in TypeScript webpack configs (e.g. `import * as pkg from './package.json'`) fails with TS2732 even when the user's tsconfig has `resolveJsonModule: true`, because ts-node's explicit `compilerOptions` override in `load-module.ts` does not include `resolveJsonModule`, which resets it to the default `false`.

Issue Number: #816

## What is the new behavior?

`resolveJsonModule: true` is added to the explicit `compilerOptions` passed to `ts-node.register()`, so JSON imports work in TypeScript webpack config files.

New integration test: `custom-webpack: TS config with JSON import`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

`resolveJsonModule` is a permissive flag — it enables a behavior that was previously rejected. No existing valid config can be broken by this change.

## Other information

**Note:** This PR modifies `load-module.ts` which is also rewritten by PR #1659. If #1659 merges first, this fix needs to be applied to `register-ts-project.ts` instead.