### PR TITLE
fix(common): make ts-node an optional peer dependency (fixes #1638)

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,11 +25,18 @@
   },
   "dependencies": {
     "@angular-devkit/core": "^21.0.0",
-    "ts-node": "^10.0.0",
     "tsconfig-paths": "^4.2.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.0",
     "typescript": "5.9.3"
+  },
+  "peerDependencies": {
+    "ts-node": "^10.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    }
   }
 }

--- a/packages/custom-esbuild/package.json
+++ b/packages/custom-esbuild/package.json
@@ -47,6 +47,7 @@
   "peerDependencies": {
     "@angular/compiler-cli": "^21.0.0",
     "rxjs": ">=7.0.0",
+    "ts-node": "^10.0.0",
     "vitest": ">=2"
   },
   "devDependencies": {
@@ -55,5 +56,10 @@
     "rimraf": "^6.0.0",
     "ts-node": "^10.0.0",
     "typescript": "5.9.3"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    }
   }
 }

--- a/packages/custom-webpack/package.json
+++ b/packages/custom-webpack/package.json
@@ -49,12 +49,18 @@
   },
   "peerDependencies": {
     "@angular/compiler-cli": "^21.0.0",
-    "rxjs": ">=7.0.0"
+    "rxjs": ">=7.0.0",
+    "ts-node": "^10.0.0"
   },
   "devDependencies": {
     "jest": "30.4.2",
     "rimraf": "^6.0.0",
     "ts-node": "^10.0.0",
     "typescript": "5.9.3"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    }
   }
 }

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -53,7 +53,8 @@
     "@angular/core": "^21.0.0",
     "@angular/platform-browser-dynamic": "^21.0.0",
     "jest": "^30.0.0",
-    "rxjs": ">=7.0.0"
+    "rxjs": ">=7.0.0",
+    "ts-node": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
@@ -62,5 +63,10 @@
     "quicktype": "^15.0.260",
     "rimraf": "^6.0.0",
     "typescript": "5.9.3"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,9 +190,13 @@ __metadata:
   dependencies:
     "@angular-devkit/core": ^21.0.0
     rimraf: ^6.0.0
-    ts-node: ^10.0.0
     tsconfig-paths: ^4.2.0
     typescript: 5.9.3
+  peerDependencies:
+    ts-node: ^10.0.0
+  peerDependenciesMeta:
+    ts-node:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -212,7 +216,11 @@ __metadata:
   peerDependencies:
     "@angular/compiler-cli": ^21.0.0
     rxjs: ">=7.0.0"
+    ts-node: ^10.0.0
     vitest: ">=2"
+  peerDependenciesMeta:
+    ts-node:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -234,6 +242,10 @@ __metadata:
   peerDependencies:
     "@angular/compiler-cli": ^21.0.0
     rxjs: ">=7.0.0"
+    ts-node: ^10.0.0
+  peerDependenciesMeta:
+    ts-node:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -259,6 +271,10 @@ __metadata:
     "@angular/platform-browser-dynamic": ^21.0.0
     jest: ^30.0.0
     rxjs: ">=7.0.0"
+    ts-node: ^10.0.0
+  peerDependenciesMeta:
+    ts-node:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`ts-node` is a hard `dependency` of `@angular-builders/common`, so it is always installed even for users whose build configs are plain JavaScript or MJS files that never require TypeScript compilation.

Issue Number: #1638

## What is the new behavior?

`ts-node` is moved to `peerDependencies` with `optional: true` across `@angular-builders/common`, `@angular-builders/custom-esbuild`, `@angular-builders/custom-webpack`, and `@angular-builders/jest`. Users who load TypeScript config files must install `ts-node` explicitly; users with JS/MJS-only configs no longer need it.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

Users who relied on `ts-node` being auto-installed as a transitive dependency will see a missing-module error at runtime when loading a `.ts` config file.

**Migration path:** If you use TypeScript configuration files (e.g. `webpack.config.ts`, custom esbuild plugins in `.ts`), add `ts-node` explicitly to your project's `devDependencies`:

```
npm install --save-dev ts-node
# or
yarn add --dev ts-node
```

No change is needed if your build config is already JavaScript or MJS.

## Other information

`ts-node` is only invoked inside `loadModule()` in `@angular-builders/common` when the resolved file extension is `.ts`. The runtime guard ensures the optional peer is only required when actually needed.