### PR TITLE
docs(custom-webpack): document ts-node configuration for custom tsconfig (fixes #1162)

### DIFF
--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -607,21 +607,6 @@ For example, to make `target` and `paths` available specifically when ts-node lo
 }
 ```
 
-Or, to use an entirely different `tsconfig` file for `ts-node`:
-
-`tsconfig.json`:
-
-```json
-{
-  "compilerOptions": {
-    ...
-  },
-  "ts-node": {
-    "tsconfig": "./tsconfig.ts-node.json"
-  }
-}
-```
-
 > **Note:** ts-node is registered once per builder run; the first tsconfig encountered governs subsequent loads in the same process. If you have both an `indexTransform.ts` and a `webpack.config.ts`, both will resolve against the same ts-node configuration.
 
 > Some options the builder explicitly overrides (notably `module: "commonjs"`) cannot be changed through this mechanism. Use it for options the builder doesn't hard-code.

--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -249,10 +249,12 @@ External `karma.conf.js` configuration:
 Starting with Angular v20, generating an [external karma config](https://angular.dev/guide/testing#configuration) will cause tests to hang while utilizing `@angular-builders/custom-webpack:karma`.
 
 Fix this by:
+
 - adding `'@angular-devkit/build-angular'` to the `frameworks` array
 - adding `'@angular-devkit/build-angular/plugins/karma'` to the `plugins` array
 
 `karma.conf.js` example:
+
 ```js
 module.exports = function (config) {
   config.set({
@@ -583,11 +585,12 @@ Full example [here](../../examples/custom-webpack/full-cycle-app).
 
 ### Using a Custom TypeScript Configuration for indexTransform
 
-If your `indexTransform` file requires a different TypeScript configuration than the default `tsConfig` from the build target, you can specify it using the `ts-node` section in your `tsconfig.json`.
+If your `indexTransform` file requires different TypeScript settings than the build target's `tsConfig` (different `target`, custom `paths`, additional `lib` entries, etc.), you can specify them via the `ts-node` section of your `tsconfig.json`. The builder picks up these options when registering ts-node for transform/config loading.
 
-For example, if you want your `indexTransform.ts` to use a different `tsconfig` file:
+For example, to make `target` and `paths` available specifically when ts-node loads your transform:
 
 `tsconfig.json`:
+
 ```json
 {
   "compilerOptions": {
@@ -595,7 +598,10 @@ For example, if you want your `indexTransform.ts` to use a different `tsconfig` 
   },
   "ts-node": {
     "compilerOptions": {
-      "module": "commonjs"
+      "target": "ES2022",
+      "paths": {
+        "@shared/*": ["./shared/*"]
+      }
     }
   }
 }
@@ -604,6 +610,7 @@ For example, if you want your `indexTransform.ts` to use a different `tsconfig` 
 Or, to use an entirely different `tsconfig` file for `ts-node`:
 
 `tsconfig.json`:
+
 ```json
 {
   "compilerOptions": {
@@ -615,7 +622,11 @@ Or, to use an entirely different `tsconfig` file for `ts-node`:
 }
 ```
 
-This is useful when your `indexTransform` has different transpilation requirements than the main build (e.g., different module format, different target, or different lib configuration). For more details on `ts-node` configuration options, see the [ts-node documentation](https://typestrong.org/ts-node/docs/configuration/#via-tsconfigjson-recommended).
+> **Note:** ts-node is registered once per builder run; the first tsconfig encountered governs subsequent loads in the same process. If you have both an `indexTransform.ts` and a `webpack.config.ts`, both will resolve against the same ts-node configuration.
+
+> Some options the builder explicitly overrides (notably `module: "commonjs"`) cannot be changed through this mechanism. Use it for options the builder doesn't hard-code.
+
+For more details on `ts-node` configuration options, see the [ts-node documentation](https://typestrong.org/ts-node/docs/configuration/#via-tsconfigjson-recommended).
 
 The same approach applies to `customWebpackConfig` if it's written in TypeScript.
 

--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -21,6 +21,7 @@ Allow customizing build configuration without ejecting webpack configuration (`n
   - [Custom Webpack Promisified Config](#custom-webpack-promisified-config)
   - [Custom Webpack Config Function](#custom-webpack-config-function)
 - [Index Transform](#index-transform)
+  - [Using a Custom TypeScript Configuration for indexTransform](#using-a-custom-typescript-configuration-for-indextransform)
   - [Example](#example-2)
 - [ES Modules (ESM) Support](#es-modules-esm-support)
 - [Verbose Logging](#verbose-logging)
@@ -29,7 +30,6 @@ Allow customizing build configuration without ejecting webpack configuration (`n
 # This documentation is for the latest major version only
 
 > ⚠️ **Version alignment:** The major version of `@angular-builders/custom-webpack` must match the major version of `@angular/core` in your project. For example, Angular 19 requires `@angular-builders/custom-webpack@19.x`, Angular 20 requires `@angular-builders/custom-webpack@20.x`, etc. Using a mismatched version is the most common source of issues.
-
 
 ## Previous versions
 
@@ -416,7 +416,6 @@ You can check out an example for plugins merge in the [unit tests](./src/webpack
 >
 > For full control over the merge, use a [function export](#custom-webpack-config-function) — you receive the full base config and return a new one, bypassing automatic merge entirely.
 
-
 ## Custom Webpack Promisified Config
 
 Webpack config can also export a `Promise` object that resolves custom config. Given the following example:
@@ -581,6 +580,44 @@ export default (targetOptions: TargetOptions, indexHtml: string) => {
 In the example we add a paragraph with build configuration to your `index.html`. It is a very simple example without any asynchronous code but you can also return a `Promise` from this function.
 
 Full example [here](../../examples/custom-webpack/full-cycle-app).
+
+### Using a Custom TypeScript Configuration for indexTransform
+
+If your `indexTransform` file requires a different TypeScript configuration than the default `tsConfig` from the build target, you can specify it using the `ts-node` section in your `tsconfig.json`.
+
+For example, if you want your `indexTransform.ts` to use a different `tsconfig` file:
+
+`tsconfig.json`:
+```json
+{
+  "compilerOptions": {
+    ...
+  },
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  }
+}
+```
+
+Or, to use an entirely different `tsconfig` file for `ts-node`:
+
+`tsconfig.json`:
+```json
+{
+  "compilerOptions": {
+    ...
+  },
+  "ts-node": {
+    "tsconfig": "./tsconfig.ts-node.json"
+  }
+}
+```
+
+This is useful when your `indexTransform` has different transpilation requirements than the main build (e.g., different module format, different target, or different lib configuration). For more details on `ts-node` configuration options, see the [ts-node documentation](https://typestrong.org/ts-node/docs/configuration/#via-tsconfigjson-recommended).
+
+The same approach applies to `customWebpackConfig` if it's written in TypeScript.
 
 # ES Modules (ESM) Support
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

No documentation explaining how to configure ts-node behavior (e.g. module resolution, custom tsconfig) for custom webpack config files and index transform files.

Issue Number: #1162

## What is the new behavior?

The custom-webpack README includes a section explaining that ts-node configuration can be provided via the `ts-node` section in `tsconfig.json`, with examples for both inline `compilerOptions` overrides and pointing to a separate tsconfig file via `ts-node.tsconfig`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

This is a docs-only change. The feature was already working — users just lacked documentation on how to configure it.