### PR TITLE
fix(jest): suppress warning when jest config is provided inline in angular.json (fixes #1102)

### DIFF
--- a/examples/jest/simple-app/angular.json
+++ b/examples/jest/simple-app/angular.json
@@ -106,6 +106,13 @@
             "zoneless": false
           }
         },
+        "test-inline-config": {
+          "builder": "@angular-builders/jest:run",
+          "options": {
+            "config": { "testTimeout": 10000, "verbose": true },
+            "zoneless": false
+          }
+        },
         "e2e": {
           "builder": "@cypress/schematic:cypress",
           "options": {

--- a/examples/jest/simple-app/package.json
+++ b/examples/jest/simple-app/package.json
@@ -7,6 +7,7 @@
     "test": "ng test",
     "test:ts": "ng run simple-app:test-ts-config",
     "test:esm": "ng run simple-app:test-esm-config",
+    "test:inline-config": "ng run simple-app:test-inline-config",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "cypress:open": "cypress open",

--- a/packages/jest/src/custom-config.resolver.spec.ts
+++ b/packages/jest/src/custom-config.resolver.spec.ts
@@ -65,13 +65,19 @@ describe('Resolve project custom config', () => {
     expect(customConfig).toEqual({});
   });
 
-  it('should log a warning when the custom configuration is not found', async () => {
+  it('should log a warning when an explicitly configured custom configuration is not found', async () => {
     existsSyncMock.mockReturnValue(false);
     await customConfigResolver.resolveForProject(
       normalize('./myproject'),
       'project-jest.config.js'
     );
     expect(mockLogger.warn.mock.calls.length).toBe(1);
+  });
+
+  it('should NOT warn when the schema default jest.config.js is absent', async () => {
+    existsSyncMock.mockReturnValue(false);
+    await customConfigResolver.resolveForProject(normalize('./myproject'), 'jest.config.js');
+    expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 
   it('Should parse and return inline JSON configuration', async () => {
@@ -87,28 +93,19 @@ describe('Resolve project custom config', () => {
 
   it('Should treat non-JSON string as file path', async () => {
     existsSyncMock.mockReturnValue(false);
-    await customConfigResolver.resolveForProject(
-      normalize('./myproject'),
-      'jest.config.js'
-    );
+    await customConfigResolver.resolveForProject(normalize('./myproject'), 'jest.config.js');
     expect(existsSyncMock).toHaveBeenCalled();
   });
 
   it('Should treat invalid JSON as file path', async () => {
     existsSyncMock.mockReturnValue(false);
-    await customConfigResolver.resolveForProject(
-      normalize('./myproject'),
-      '{invalid json'
-    );
+    await customConfigResolver.resolveForProject(normalize('./myproject'), '{invalid json');
     expect(existsSyncMock).toHaveBeenCalled();
   });
 
   it('Should not treat JSON array as config', async () => {
     existsSyncMock.mockReturnValue(false);
-    await customConfigResolver.resolveForProject(
-      normalize('./myproject'),
-      '["item1", "item2"]'
-    );
+    await customConfigResolver.resolveForProject(normalize('./myproject'), '["item1", "item2"]');
     // Arrays should be treated as file paths, not config objects
     expect(existsSyncMock).toHaveBeenCalled();
   });

--- a/packages/jest/src/custom-config.resolver.ts
+++ b/packages/jest/src/custom-config.resolver.ts
@@ -54,9 +54,16 @@ export class CustomConfigResolver {
     // Treat as file path
     const jestConfigPath = getSystemPath(join(projectRoot, configPath));
     if (!existsSync(jestConfigPath)) {
-      this.logger.warn(
-        `warning: unable to locate custom jest configuration file at path "${jestConfigPath}"`
-      );
+      // Only warn when the user explicitly pointed at a missing file.
+      // 'jest.config.js' is the schema default — best-effort discovery —
+      // and is legitimately absent when the user keeps config elsewhere
+      // (package.json `jest`, workspace-level jest.config.*, or an inline
+      // JestConfig object in angular.json). See #1102.
+      if (configPath !== 'jest.config.js') {
+        this.logger.warn(
+          `warning: unable to locate custom jest configuration file at path "${jestConfigPath}"`
+        );
+      }
       return {};
     }
     const tsConfig = getTsConfigPath(projectRoot, this.options);

--- a/packages/jest/src/custom-config.resolver.ts
+++ b/packages/jest/src/custom-config.resolver.ts
@@ -4,7 +4,7 @@ import { loadModule } from '@angular-builders/common';
 
 import { JestConfig } from './types';
 import { SchemaObject as JestBuilderSchema } from './schema';
-import { getTsConfigPath } from './utils';
+import { DEFAULT_JEST_CONFIG, getTsConfigPath } from './utils';
 
 export class CustomConfigResolver {
   // https://jestjs.io/docs/configuration
@@ -55,11 +55,11 @@ export class CustomConfigResolver {
     const jestConfigPath = getSystemPath(join(projectRoot, configPath));
     if (!existsSync(jestConfigPath)) {
       // Only warn when the user explicitly pointed at a missing file.
-      // 'jest.config.js' is the schema default — best-effort discovery —
+      // DEFAULT_JEST_CONFIG (the schema default) is best-effort discovery —
       // and is legitimately absent when the user keeps config elsewhere
       // (package.json `jest`, workspace-level jest.config.*, or an inline
       // JestConfig object in angular.json). See #1102.
-      if (configPath !== 'jest.config.js') {
+      if (configPath !== DEFAULT_JEST_CONFIG) {
         this.logger.warn(
           `warning: unable to locate custom jest configuration file at path "${jestConfigPath}"`
         );

--- a/packages/jest/src/utils.ts
+++ b/packages/jest/src/utils.ts
@@ -1,7 +1,12 @@
 import { getSystemPath, join, Path } from '@angular-devkit/core';
 import { SchemaObject as JestBuilderSchema } from './schema';
+import * as jestRunnerSchema from './schema.json';
 
 export const tsConfigName = 'tsconfig.spec.json';
+
+// The default jest config path, sourced from the builder schema so it can never
+// drift from the value Angular materializes for an unset `config` option. See #1102.
+export const DEFAULT_JEST_CONFIG = jestRunnerSchema.properties.config.default;
 export function getTsConfigPath(projectRoot: Path, options: JestBuilderSchema) {
   return getSystemPath(join(projectRoot, options.tsConfig || tsConfigName));
 }

--- a/packages/jest/tests/integration.js
+++ b/packages/jest/tests/integration.js
@@ -14,6 +14,15 @@ module.exports = [
     app: 'examples/jest/simple-app',
     command: 'yarn test:esm --no-cache',
   },
+  {
+    id: 'config-inline-object',
+    name: 'jest: inline config object in angular.json',
+    purpose:
+      'Builder runs tests successfully when config is an inline object in angular.json, not a file path (no spurious warning, no crash)',
+    app: 'examples/jest/simple-app',
+    command:
+      'node ../../../packages/jest/tests/validate.js --run-script=test:inline-config --no-cache --expect-suites=2 --expect-tests=4',
+  },
 
   // CLI passthrough - validated tests
   {

--- a/packages/jest/tests/validate.js
+++ b/packages/jest/tests/validate.js
@@ -2,15 +2,18 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 
-// Parse args: separate jest args from --expect-* args
+// Parse args: separate jest args from --expect-* and --run-script=* args
 const jestArgs = [];
 const expectations = {};
+let runScript = 'test';
 
 for (let i = 2; i < process.argv.length; i++) {
   const arg = process.argv[i];
   if (arg.startsWith('--expect-')) {
     const [key, value] = arg.slice(9).split('=');
     expectations[key] = value;
+  } else if (arg.startsWith('--run-script=')) {
+    runScript = arg.slice('--run-script='.length);
   } else {
     jestArgs.push(arg);
   }
@@ -19,11 +22,11 @@ for (let i = 2; i < process.argv.length; i++) {
 // Quote args that contain spaces
 const quotedArgs = jestArgs.map(arg => (arg.includes(' ') ? `"${arg}"` : arg));
 
-console.log(`Running: yarn test ${quotedArgs.join(' ')}`);
+console.log(`Running: yarn ${runScript} ${quotedArgs.join(' ')}`);
 console.log(`Expectations:`, expectations);
 
 // Capture both stdout and stderr
-const output = execSync(`yarn test ${quotedArgs.join(' ')} 2>&1`, {
+const output = execSync(`yarn ${runScript} ${quotedArgs.join(' ')} 2>&1`, {
   encoding: 'utf-8',
 });
 

--- a/packages/jest/tsconfig.json
+++ b/packages/jest/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
   "files": [],
   "include": [],
   "references": [


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Projects that don't set `config` in `angular.json` rely on the schema default `jest.config.js`. When that file isn't present (because the user keeps their config in `package.json`, at workspace level, or as an inline JestConfig object), the builder logs `warning: unable to locate custom jest configuration file at path …` on every run. That's the default-discovery path — absence is normal, not user error. See #1102 (`melroy89` 2025-05-25 confirms it still fires on package.json-embedded configs).

Issue Number: #1102

## What is the new behavior?

The warning fires only when the configured path is not the schema default. `config: "jest.config.js"` (the default) absent → silent. `config: "my-custom-jest.config.ts"` absent → still warns, because the user explicitly pointed at a file.

Inline-object and inline-JSON-string configs are unchanged — they already short-circuit before the file-existence check (master, since #7bfe3123).

New unit test: `should NOT warn when the schema default jest.config.js is absent`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

The warning text was advisory only; suppressing it for the default-discovery case doesn't change config resolution. Users who relied on the warning to detect a typo'd path still get it.

## Other information

Branch was force-pushed to drop unrelated noise (commitlint downgrade, CHANGELOG entry removals, yarn.lock churn).