### PR TITLE
chore(renovate): hold typescript majors until Angular CLI catches up

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,12 @@
       "description": "Track GitHub-hosted runner image versions (runs-on), but never auto-merge them - a runner bump can change the CI environment and must be reviewed/tested.",
       "matchDatasources": ["github-runners"],
       "automerge": false
+    },
+    {
+      "description": "Hold TypeScript majors until Angular CLI's supported versions catch up — see #2123.",
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Renovate opens PRs to bump TypeScript past Angular CLI's supported window — most recently #2123 (closed) tried to bring in TypeScript 6 before Angular 21 supported it. Adopting TS majors early causes split-brain (examples vs packages) and forces `ignoreDeprecations` workarounds that mask real issues.

## What is the new behavior?

A new `packageRules` entry in `renovate.json` disables major updates for `typescript`. Minor/patch updates still flow normally. When Angular publishes support for a new TS major, this rule can be removed to allow the bump.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

N/A