### PR TITLE
chore: declare @angular/build at repo root for merge-schemes.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "update:examples": "yarn workspaces foreach --exclude '@angular-builders/*' run update:example"
   },
   "devDependencies": {
+    "@angular/build": "^21.0.0",
     "@commitlint/cli": "^21.0.0",
     "@commitlint/config-conventional": "^21.0.0",
     "@lerna-lite/cli": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9134,6 +9134,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "angular-builders@workspace:."
   dependencies:
+    "@angular/build": ^21.0.0
     "@commitlint/cli": ^21.0.0
     "@commitlint/config-conventional": ^21.0.0
     "@lerna-lite/cli": ^5.0.0


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`merge-schemes.ts` (the root build script that produces builder schemas) calls `resolvePackagePath('@angular/build', …)` to find Angular's internal schema files. Neither root `package.json` nor `packages/common` declares `@angular/build`. The resolution works on master purely because Yarn hoists `@angular/build` from `packages/custom-esbuild`/`packages/custom-webpack` into the top-level `node_modules`. Any change to hoist layout (e.g. the TS6 bump that surfaced PR #2229's CI failure) silently breaks the build with `Cannot find module '@angular/build/package.json'`.

## What is the new behavior?

`@angular/build` is added to root `devDependencies` with the same major range used elsewhere. The build-time use is now declared at the same level it actually runs.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Could also be placed in `packages/common`'s `dependencies`, but the function is only ever called from the root `merge-schemes.ts` script, and `common` is a published package — pulling `@angular/build` into all consumers (including `jest`, which doesn't need it) would be overkill.