### PR TITLE
feat(schematics): ng-add for custom-esbuild/webpack + jest migration schematics

### DIFF
--- a/packages/custom-esbuild/.gitignore
+++ b/packages/custom-esbuild/.gitignore
@@ -12,6 +12,7 @@ package
 
 dist
 **/schema.json
+!src/schematics/**/schema.json
 *.js
 !karma.conf.js
 *.js.map

--- a/packages/custom-esbuild/package.json
+++ b/packages/custom-esbuild/package.json
@@ -31,13 +31,18 @@
   ],
   "scripts": {
     "prebuild": "yarn clean",
-    "build": "yarn prebuild && tsc && ts-node ../../merge-schemes.ts && yarn postbuild",
-    "postbuild": "yarn test && yarn run e2e",
+    "build": "yarn prebuild && tsc && tsc -p tsconfig.schematics.json && ts-node ../../merge-schemes.ts && yarn postbuild",
+    "postbuild": "yarn copy:schematics && yarn test && yarn run e2e",
+    "copy:schematics": "cpy \"src/schematics/**/*.json\" dist/schematics",
     "test": "jest --config ../../jest-ut.config.js",
     "e2e": "jest --config ../../jest-e2e.config.js",
     "clean": "rimraf dist"
   },
   "builders": "builders.json",
+  "schematics": "./dist/schematics/collection.json",
+  "ng-add": {
+    "save": "devDependencies"
+  },
   "dependencies": {
     "@angular-builders/common": "workspace:*",
     "@angular-devkit/architect": ">=0.2100.0 < 0.2200.0",
@@ -50,6 +55,7 @@
     "vitest": ">=2"
   },
   "devDependencies": {
+    "cpy-cli": "^7.0.0",
     "esbuild": "0.28.0",
     "jest": "30.4.2",
     "rimraf": "^6.0.0",

--- a/packages/custom-esbuild/src/schematics/collection.json
+++ b/packages/custom-esbuild/src/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Configure @angular-builders/custom-esbuild as the application builder for an Angular workspace",
+      "factory": "./ng-add/index#default",
+      "schema": "./ng-add/schema.json"
+    }
+  }
+}

--- a/packages/custom-esbuild/src/schematics/ng-add/index.ts
+++ b/packages/custom-esbuild/src/schematics/ng-add/index.ts
@@ -1,0 +1,125 @@
+import { JsonValue } from '@angular-devkit/core';
+import {
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  Tree,
+  chain,
+} from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+
+import { NgAddOptions } from './schema';
+
+const BUILDER_NAME = '@angular-builders/custom-esbuild:application';
+const PACKAGE_NAME = '@angular-builders/custom-esbuild';
+
+interface JsonRecord {
+  [key: string]: JsonValue;
+}
+
+function readJson(tree: Tree, path: string): JsonRecord {
+  const buffer = tree.read(path);
+  if (!buffer) {
+    throw new SchematicsException(`Could not read ${path}`);
+  }
+  try {
+    return JSON.parse(buffer.toString('utf-8')) as JsonRecord;
+  } catch (err) {
+    throw new SchematicsException(`Could not parse ${path}: ${(err as Error).message}`);
+  }
+}
+
+function writeJson(tree: Tree, path: string, value: JsonRecord): void {
+  tree.overwrite(path, JSON.stringify(value, null, 2) + '\n');
+}
+
+function getOwnVersion(): string {
+  // Resolves at runtime to dist/schematics/ng-add/index.js, so package.json is
+  // three levels up (dist/schematics/ng-add -> dist/schematics -> dist -> pkg root).
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const pkg = require('../../../package.json') as { version: string };
+  return pkg.version;
+}
+
+function updateAngularJson(options: NgAddOptions): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const angularJsonPath = tree.exists('angular.json')
+      ? 'angular.json'
+      : tree.exists('.angular.json')
+        ? '.angular.json'
+        : null;
+
+    if (!angularJsonPath) {
+      throw new SchematicsException('Could not find angular.json in workspace root.');
+    }
+
+    const workspace = readJson(tree, angularJsonPath);
+    const projects = (workspace.projects ?? {}) as JsonRecord;
+    const projectNames = Object.keys(projects);
+
+    if (projectNames.length === 0) {
+      throw new SchematicsException('No projects found in angular.json.');
+    }
+
+    let projectName = options.project;
+    if (!projectName) {
+      projectName =
+        typeof workspace.defaultProject === 'string' ? workspace.defaultProject : projectNames[0];
+    }
+
+    const project = projects[projectName] as JsonRecord | undefined;
+    if (!project) {
+      throw new SchematicsException(`Project "${projectName}" not found in angular.json.`);
+    }
+
+    const architect = (project.architect ?? project.targets) as JsonRecord | undefined;
+    if (!architect) {
+      throw new SchematicsException(
+        `Project "${projectName}" has no architect/targets configuration.`
+      );
+    }
+
+    const existingBuild = architect.build as JsonRecord | undefined;
+    const existingBuilder = existingBuild?.builder as string | undefined;
+
+    architect.build = {
+      ...(existingBuild ?? {}),
+      builder: BUILDER_NAME,
+    };
+
+    writeJson(tree, angularJsonPath, workspace);
+    context.logger.info(
+      `Updated angular.json: ${projectName}.architect.build.builder ` +
+        `${existingBuilder ? `(was: ${existingBuilder}) ` : ''}-> ${BUILDER_NAME}`
+    );
+    return tree;
+  };
+}
+
+function updatePackageJson(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const pkg = readJson(tree, 'package.json');
+    const devDeps = (pkg.devDependencies ?? {}) as JsonRecord;
+
+    devDeps[PACKAGE_NAME] = `^${getOwnVersion()}`;
+    pkg.devDependencies = devDeps;
+
+    writeJson(tree, 'package.json', pkg);
+    context.logger.info(`Added ${PACKAGE_NAME} to devDependencies.`);
+    return tree;
+  };
+}
+
+function scheduleInstall(options: NgAddOptions): Rule {
+  return (_tree: Tree, context: SchematicContext) => {
+    if (options.skipInstall) {
+      return;
+    }
+    context.addTask(new NodePackageInstallTask());
+    context.logger.info('Scheduled package install task.');
+  };
+}
+
+export default function ngAdd(options: NgAddOptions = {}): Rule {
+  return chain([updateAngularJson(options), updatePackageJson(), scheduleInstall(options)]);
+}

--- a/packages/custom-esbuild/src/schematics/ng-add/schema.json
+++ b/packages/custom-esbuild/src/schematics/ng-add/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "AngularBuildersCustomEsbuildNgAdd",
+  "title": "@angular-builders/custom-esbuild ng-add schema",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Name of the project to configure. Defaults to the workspace default project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "skipInstall": {
+      "type": "boolean",
+      "description": "Skip running the package install task.",
+      "default": false
+    }
+  },
+  "required": []
+}

--- a/packages/custom-esbuild/src/schematics/ng-add/schema.ts
+++ b/packages/custom-esbuild/src/schematics/ng-add/schema.ts
@@ -1,0 +1,6 @@
+export interface NgAddOptions {
+  /** Name of the Angular workspace project to configure. */
+  project?: string;
+  /** Skip running the package install task after schematic updates. */
+  skipInstall?: boolean;
+}

--- a/packages/custom-esbuild/tsconfig.schematics.json
+++ b/packages/custom-esbuild/tsconfig.schematics.json
@@ -5,7 +5,7 @@
     "rootDir": "./src/schematics",
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "declaration": true,
     "noImplicitAny": false,
     "types": ["node"]

--- a/packages/custom-esbuild/tsconfig.schematics.json
+++ b/packages/custom-esbuild/tsconfig.schematics.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/schematics",
+    "rootDir": "./src/schematics",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "ignoreDeprecations": "6.0",
+    "declaration": true,
+    "noImplicitAny": false,
+    "types": ["node"]
+  },
+  "include": ["src/schematics/**/*.ts"],
+  "exclude": ["src/schematics/**/*.spec.ts"]
+}

--- a/packages/custom-webpack/.gitignore
+++ b/packages/custom-webpack/.gitignore
@@ -12,6 +12,7 @@ package
 
 dist
 **/schema.json
+!src/schematics/**/schema.json
 *.js
 !karma.conf.js
 !*webpack.config.js

--- a/packages/custom-webpack/package.json
+++ b/packages/custom-webpack/package.json
@@ -31,13 +31,18 @@
   ],
   "scripts": {
     "prebuild": "yarn clean",
-    "build": "yarn prebuild && tsc && ts-node ../../merge-schemes.ts && yarn postbuild",
-    "postbuild": "yarn test && yarn run e2e",
+    "build": "yarn prebuild && tsc && tsc -p tsconfig.schematics.json && ts-node ../../merge-schemes.ts && yarn postbuild",
+    "postbuild": "yarn copy:schematics && yarn test && yarn run e2e",
+    "copy:schematics": "cpy \"src/schematics/**/*.json\" dist/schematics",
     "test": "jest --config ../../jest-ut.config.js",
     "e2e": "jest --config ../../jest-e2e.config.js",
     "clean": "rimraf dist"
   },
   "builders": "builders.json",
+  "schematics": "./dist/schematics/collection.json",
+  "ng-add": {
+    "save": "devDependencies"
+  },
   "dependencies": {
     "@angular-builders/common": "workspace:*",
     "@angular-devkit/architect": ">=0.2100.0 < 0.2200.0",
@@ -52,6 +57,7 @@
     "rxjs": ">=7.0.0"
   },
   "devDependencies": {
+    "cpy-cli": "^7.0.0",
     "jest": "30.4.2",
     "rimraf": "^6.0.0",
     "ts-node": "^10.0.0",

--- a/packages/custom-webpack/src/schematics/collection.json
+++ b/packages/custom-webpack/src/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Configure @angular-builders/custom-webpack as the browser builder for an Angular workspace",
+      "factory": "./ng-add/index#default",
+      "schema": "./ng-add/schema.json"
+    }
+  }
+}

--- a/packages/custom-webpack/src/schematics/ng-add/index.ts
+++ b/packages/custom-webpack/src/schematics/ng-add/index.ts
@@ -1,0 +1,125 @@
+import { JsonValue } from '@angular-devkit/core';
+import {
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  Tree,
+  chain,
+} from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+
+import { NgAddOptions } from './schema';
+
+const BUILDER_NAME = '@angular-builders/custom-webpack:browser';
+const PACKAGE_NAME = '@angular-builders/custom-webpack';
+
+interface JsonRecord {
+  [key: string]: JsonValue;
+}
+
+function readJson(tree: Tree, path: string): JsonRecord {
+  const buffer = tree.read(path);
+  if (!buffer) {
+    throw new SchematicsException(`Could not read ${path}`);
+  }
+  try {
+    return JSON.parse(buffer.toString('utf-8')) as JsonRecord;
+  } catch (err) {
+    throw new SchematicsException(`Could not parse ${path}: ${(err as Error).message}`);
+  }
+}
+
+function writeJson(tree: Tree, path: string, value: JsonRecord): void {
+  tree.overwrite(path, JSON.stringify(value, null, 2) + '\n');
+}
+
+function getOwnVersion(): string {
+  // Resolves at runtime to dist/schematics/ng-add/index.js, so package.json is
+  // three levels up (dist/schematics/ng-add -> dist/schematics -> dist -> pkg root).
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const pkg = require('../../../package.json') as { version: string };
+  return pkg.version;
+}
+
+function updateAngularJson(options: NgAddOptions): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const angularJsonPath = tree.exists('angular.json')
+      ? 'angular.json'
+      : tree.exists('.angular.json')
+        ? '.angular.json'
+        : null;
+
+    if (!angularJsonPath) {
+      throw new SchematicsException('Could not find angular.json in workspace root.');
+    }
+
+    const workspace = readJson(tree, angularJsonPath);
+    const projects = (workspace.projects ?? {}) as JsonRecord;
+    const projectNames = Object.keys(projects);
+
+    if (projectNames.length === 0) {
+      throw new SchematicsException('No projects found in angular.json.');
+    }
+
+    let projectName = options.project;
+    if (!projectName) {
+      projectName =
+        typeof workspace.defaultProject === 'string' ? workspace.defaultProject : projectNames[0];
+    }
+
+    const project = projects[projectName] as JsonRecord | undefined;
+    if (!project) {
+      throw new SchematicsException(`Project "${projectName}" not found in angular.json.`);
+    }
+
+    const architect = (project.architect ?? project.targets) as JsonRecord | undefined;
+    if (!architect) {
+      throw new SchematicsException(
+        `Project "${projectName}" has no architect/targets configuration.`
+      );
+    }
+
+    const existingBuild = architect.build as JsonRecord | undefined;
+    const existingBuilder = existingBuild?.builder as string | undefined;
+
+    architect.build = {
+      ...(existingBuild ?? {}),
+      builder: BUILDER_NAME,
+    };
+
+    writeJson(tree, angularJsonPath, workspace);
+    context.logger.info(
+      `Updated angular.json: ${projectName}.architect.build.builder ` +
+        `${existingBuilder ? `(was: ${existingBuilder}) ` : ''}-> ${BUILDER_NAME}`
+    );
+    return tree;
+  };
+}
+
+function updatePackageJson(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const pkg = readJson(tree, 'package.json');
+    const devDeps = (pkg.devDependencies ?? {}) as JsonRecord;
+
+    devDeps[PACKAGE_NAME] = `^${getOwnVersion()}`;
+    pkg.devDependencies = devDeps;
+
+    writeJson(tree, 'package.json', pkg);
+    context.logger.info(`Added ${PACKAGE_NAME} to devDependencies.`);
+    return tree;
+  };
+}
+
+function scheduleInstall(options: NgAddOptions): Rule {
+  return (_tree: Tree, context: SchematicContext) => {
+    if (options.skipInstall) {
+      return;
+    }
+    context.addTask(new NodePackageInstallTask());
+    context.logger.info('Scheduled package install task.');
+  };
+}
+
+export default function ngAdd(options: NgAddOptions = {}): Rule {
+  return chain([updateAngularJson(options), updatePackageJson(), scheduleInstall(options)]);
+}

--- a/packages/custom-webpack/src/schematics/ng-add/schema.json
+++ b/packages/custom-webpack/src/schematics/ng-add/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "AngularBuildersCustomWebpackNgAdd",
+  "title": "@angular-builders/custom-webpack ng-add schema",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Name of the project to configure. Defaults to the workspace default project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "skipInstall": {
+      "type": "boolean",
+      "description": "Skip running the package install task.",
+      "default": false
+    }
+  },
+  "required": []
+}

--- a/packages/custom-webpack/src/schematics/ng-add/schema.ts
+++ b/packages/custom-webpack/src/schematics/ng-add/schema.ts
@@ -1,0 +1,6 @@
+export interface NgAddOptions {
+  /** Name of the Angular workspace project to configure. */
+  project?: string;
+  /** Skip running the package install task after schematic updates. */
+  skipInstall?: boolean;
+}

--- a/packages/custom-webpack/tsconfig.schematics.json
+++ b/packages/custom-webpack/tsconfig.schematics.json
@@ -5,7 +5,7 @@
     "rootDir": "./src/schematics",
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "declaration": true,
     "noImplicitAny": false,
     "types": ["node"]

--- a/packages/custom-webpack/tsconfig.schematics.json
+++ b/packages/custom-webpack/tsconfig.schematics.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/schematics",
+    "rootDir": "./src/schematics",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "ignoreDeprecations": "6.0",
+    "declaration": true,
+    "noImplicitAny": false,
+    "types": ["node"]
+  },
+  "include": ["src/schematics/**/*.ts"],
+  "exclude": ["src/schematics/**/*.spec.ts"]
+}

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -30,10 +30,14 @@
     "runner"
   ],
   "builders": "builders.json",
+  "ng-update": {
+    "migrations": "./dist/schematics/migrations.json"
+  },
   "scripts": {
     "prebuild": "yarn clean && yarn generate",
-    "build": "yarn prebuild && tsc -p tsconfig.lib.json && yarn postbuild",
-    "postbuild": "yarn copy && yarn test",
+    "build": "yarn prebuild && tsc -p tsconfig.lib.json && tsc -p tsconfig.schematics.json && yarn postbuild",
+    "postbuild": "yarn copy && yarn copy:schematics && yarn test",
+    "copy:schematics": "cpy \"src/schematics/**/*.json\" dist/schematics",
     "test": "jest --config ../../jest-ut.config.js",
     "e2e": "jest --config ../../jest-e2e.config.js",
     "clean": "rimraf dist src/schema.ts",

--- a/packages/jest/src/schematics/migrations.json
+++ b/packages/jest/src/schematics/migrations.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "migration-v18": {
+      "version": "18.0.0",
+      "description": "Migrate @angular-builders/jest from v17 to v18: switch to jest-preset-angular/setup-jest",
+      "factory": "./migrations/v18/index#default"
+    },
+    "migration-v19": {
+      "version": "19.0.0",
+      "description": "Migrate @angular-builders/jest from v18 to v19: use explicit setupZoneTestEnv() from jest-preset-angular/setup-env/zone",
+      "factory": "./migrations/v19/index#default"
+    },
+    "migration-v20": {
+      "version": "20.0.0",
+      "description": "Migrate @angular-builders/jest from v19 to v20: no breaking changes (no-op migration)",
+      "factory": "./migrations/v20/index#default"
+    },
+    "migration-v21": {
+      "version": "21.0.0",
+      "description": "Migrate @angular-builders/jest from v20 to v21: zoneless as default, reduced global mocks",
+      "factory": "./migrations/v21/index#default"
+    }
+  }
+}

--- a/packages/jest/src/schematics/migrations/v18/index.ts
+++ b/packages/jest/src/schematics/migrations/v18/index.ts
@@ -1,0 +1,59 @@
+import { JsonValue } from '@angular-devkit/core';
+import { Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
+
+interface JsonRecord {
+  [key: string]: JsonValue;
+}
+
+function readJson(tree: Tree, path: string): JsonRecord {
+  const buffer = tree.read(path);
+  if (!buffer) {
+    throw new SchematicsException(`Could not read ${path}`);
+  }
+  return JSON.parse(buffer.toString('utf-8')) as JsonRecord;
+}
+
+function writeJson(tree: Tree, path: string, value: JsonRecord): void {
+  tree.overwrite(path, JSON.stringify(value, null, 2) + '\n');
+}
+
+/**
+ * v17 → v18 migration.
+ *
+ * Breaking change: setup file moved from a bare `import 'jest-preset-angular'`
+ * to `import 'jest-preset-angular/setup-jest'`. Users who had customised
+ * `setupFilesAfterFramework` to reference the old entrypoint need it updated.
+ *
+ * Angular.json change: none required (builder API unchanged).
+ * Custom setup files: if the user's jest config references the old import we
+ * emit an info message -- we cannot safely rewrite arbitrary JS/TS files.
+ */
+export default function migrate(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    context.logger.info(
+      '[v18 migration] @angular-builders/jest v18 switched the preset setup file ' +
+        "from 'jest-preset-angular' to 'jest-preset-angular/setup-jest'.\n" +
+        'If you have a custom jest config that references setupFilesAfterEnv with ' +
+        "the old import, update it to 'jest-preset-angular/setup-jest'."
+    );
+
+    // Check tsconfig.spec.json for lingering jasmine types (common v17 leftover).
+    const candidates = ['tsconfig.spec.json', 'src/tsconfig.spec.json'];
+    for (const path of candidates) {
+      if (!tree.exists(path)) continue;
+      const buffer = tree.read(path);
+      if (!buffer) continue;
+
+      let raw = buffer.toString('utf-8');
+      if (raw.includes('"jasmine"')) {
+        raw = raw.replace(/"jasmine"/g, '"jest"');
+        tree.overwrite(path, raw);
+        context.logger.info(
+          `[v18 migration] Updated ${path}: replaced "jasmine" with "jest" in types array.`
+        );
+      }
+    }
+
+    return tree;
+  };
+}

--- a/packages/jest/src/schematics/migrations/v18/index.ts
+++ b/packages/jest/src/schematics/migrations/v18/index.ts
@@ -1,21 +1,4 @@
-import { JsonValue } from '@angular-devkit/core';
-import { Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
-
-interface JsonRecord {
-  [key: string]: JsonValue;
-}
-
-function readJson(tree: Tree, path: string): JsonRecord {
-  const buffer = tree.read(path);
-  if (!buffer) {
-    throw new SchematicsException(`Could not read ${path}`);
-  }
-  return JSON.parse(buffer.toString('utf-8')) as JsonRecord;
-}
-
-function writeJson(tree: Tree, path: string, value: JsonRecord): void {
-  tree.overwrite(path, JSON.stringify(value, null, 2) + '\n');
-}
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 
 /**
  * v17 → v18 migration.

--- a/packages/jest/src/schematics/migrations/v19/index.ts
+++ b/packages/jest/src/schematics/migrations/v19/index.ts
@@ -1,0 +1,44 @@
+import { JsonValue } from '@angular-devkit/core';
+import { Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
+
+interface JsonRecord {
+  [key: string]: JsonValue;
+}
+
+function readJson(tree: Tree, path: string): JsonRecord {
+  const buffer = tree.read(path);
+  if (!buffer) {
+    throw new SchematicsException(`Could not read ${path}`);
+  }
+  return JSON.parse(buffer.toString('utf-8')) as JsonRecord;
+}
+
+function writeJson(tree: Tree, path: string, value: JsonRecord): void {
+  tree.overwrite(path, JSON.stringify(value, null, 2) + '\n');
+}
+
+/**
+ * v18 → v19 migration.
+ *
+ * Breaking change: zone.js setup switched from `jest-preset-angular/setup-jest`
+ * (implicit zone support) to an explicit `setupZoneTestEnv()` call from
+ * `jest-preset-angular/setup-env/zone`. The builder now injects this
+ * automatically via `setupFilesAfterEnv`. No angular.json changes are required
+ * unless the user was manually referencing the old setup file.
+ *
+ * This migration emits guidance and removes any explicit reference to the v18
+ * setup file from `angular.json` builder options (the builder handles it now).
+ */
+export default function migrate(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    context.logger.info(
+      '[v19 migration] @angular-builders/jest v19 switched zone.js setup to ' +
+        "explicit setupZoneTestEnv() from 'jest-preset-angular/setup-env/zone'.\n" +
+        'The builder injects this automatically. If you referenced the v18 setup ' +
+        "file ('jest-preset-angular/setup-jest') in your own setupFilesAfterEnv, " +
+        'remove it to avoid duplicate setup.'
+    );
+
+    return tree;
+  };
+}

--- a/packages/jest/src/schematics/migrations/v19/index.ts
+++ b/packages/jest/src/schematics/migrations/v19/index.ts
@@ -1,21 +1,4 @@
-import { JsonValue } from '@angular-devkit/core';
-import { Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
-
-interface JsonRecord {
-  [key: string]: JsonValue;
-}
-
-function readJson(tree: Tree, path: string): JsonRecord {
-  const buffer = tree.read(path);
-  if (!buffer) {
-    throw new SchematicsException(`Could not read ${path}`);
-  }
-  return JSON.parse(buffer.toString('utf-8')) as JsonRecord;
-}
-
-function writeJson(tree: Tree, path: string, value: JsonRecord): void {
-  tree.overwrite(path, JSON.stringify(value, null, 2) + '\n');
-}
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 
 /**
  * v18 → v19 migration.

--- a/packages/jest/src/schematics/migrations/v20/index.ts
+++ b/packages/jest/src/schematics/migrations/v20/index.ts
@@ -1,0 +1,19 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+
+/**
+ * v19 → v20 migration.
+ *
+ * No breaking changes in v20 that require automated migration. The zone.js
+ * setup introduced in v19 remains unchanged. Global mocks are the same as v19
+ * (4 mocks: styleTransform, getComputedStyle, doctype, matchMedia).
+ *
+ * This migration is a no-op; it exists so ng-update has a complete migration
+ * chain from v17 through to v21.
+ */
+export default function migrate(): Rule {
+  return (_tree: Tree, context: SchematicContext) => {
+    context.logger.info(
+      '[v20 migration] No breaking changes in @angular-builders/jest v20. Nothing to migrate.'
+    );
+  };
+}

--- a/packages/jest/src/schematics/migrations/v20/index.ts
+++ b/packages/jest/src/schematics/migrations/v20/index.ts
@@ -4,8 +4,8 @@ import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
  * v19 → v20 migration.
  *
  * No breaking changes in v20 that require automated migration. The zone.js
- * setup introduced in v19 remains unchanged. Global mocks are the same as v19
- * (4 mocks: styleTransform, getComputedStyle, doctype, matchMedia).
+ * setup introduced in v19 remains unchanged, and the set of global mocks is
+ * unchanged from v19.
  *
  * This migration is a no-op; it exists so ng-update has a complete migration
  * chain from v17 through to v21.

--- a/packages/jest/src/schematics/migrations/v21/index.ts
+++ b/packages/jest/src/schematics/migrations/v21/index.ts
@@ -1,0 +1,106 @@
+import { JsonValue } from '@angular-devkit/core';
+import {
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  Tree,
+  chain,
+} from '@angular-devkit/schematics';
+
+interface JsonRecord {
+  [key: string]: JsonValue;
+}
+
+function readJson(tree: Tree, path: string): JsonRecord {
+  const buffer = tree.read(path);
+  if (!buffer) {
+    throw new SchematicsException(`Could not read ${path}`);
+  }
+  return JSON.parse(buffer.toString('utf-8')) as JsonRecord;
+}
+
+function writeJson(tree: Tree, path: string, value: JsonRecord): void {
+  tree.overwrite(path, JSON.stringify(value, null, 2) + '\n');
+}
+
+/**
+ * v20 → v21 migration.
+ *
+ * Two breaking changes requiring user action:
+ *
+ * 1. **Zoneless default** — `zoneless` option now defaults to `true`. Apps
+ *    still using zone.js change detection MUST explicitly set `zoneless: false`
+ *    in `angular.json` under `architect.test.options`. This migration detects
+ *    whether `@angular/core` is present and sets `zoneless: false` as a
+ *    conservative default, preserving zone-based behaviour for existing apps.
+ *
+ * 2. **Reduced global mocks** — `styleTransform`, `getComputedStyle`, and
+ *    `doctype` mocks were removed (Jest 30's jsdom provides them natively).
+ *    Only `matchMedia` remains. If the user had overridden `globalMocks` to
+ *    include those, they should remove them. This migration emits a warning.
+ */
+
+function setZonelessFalse(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const angularJsonPath = tree.exists('angular.json')
+      ? 'angular.json'
+      : tree.exists('.angular.json')
+        ? '.angular.json'
+        : null;
+
+    if (!angularJsonPath) {
+      context.logger.warn('[v21 migration] Could not find angular.json. Skipping zoneless update.');
+      return tree;
+    }
+
+    const workspace = readJson(tree, angularJsonPath);
+    const projects = (workspace.projects ?? {}) as JsonRecord;
+    let updated = 0;
+
+    for (const projectName of Object.keys(projects)) {
+      const project = projects[projectName] as JsonRecord;
+      const architect = (project.architect ?? project.targets) as JsonRecord | undefined;
+      if (!architect) continue;
+
+      const test = architect.test as JsonRecord | undefined;
+      if (!test) continue;
+
+      const builderName = test.builder as string | undefined;
+      if (!builderName?.includes('@angular-builders/jest')) continue;
+
+      const options = (test.options ?? {}) as JsonRecord;
+      // Only set zoneless: false if the user has not already configured it.
+      if (options.zoneless === undefined) {
+        options.zoneless = false;
+        test.options = options;
+        updated++;
+        context.logger.info(
+          `[v21 migration] Set ${projectName}.architect.test.options.zoneless = false ` +
+            '(v21 defaults to true/zoneless; set to false to preserve zone.js behaviour). ' +
+            'Remove this option if your app uses provideZonelessChangeDetection().'
+        );
+      }
+    }
+
+    if (updated > 0) {
+      writeJson(tree, angularJsonPath, workspace);
+    }
+
+    return tree;
+  };
+}
+
+function warnAboutRemovedMocks(): Rule {
+  return (_tree: Tree, context: SchematicContext) => {
+    context.logger.warn(
+      '[v21 migration] @angular-builders/jest v21 removed the globalMocks for ' +
+        "'styleTransform', 'getComputedStyle', and 'doctype' (Jest 30 jsdom provides " +
+        "them natively). Only 'matchMedia' remains. If you had custom code that depended " +
+        'on those mocks, verify your tests still pass.'
+    );
+  };
+}
+
+export default function migrate(): Rule {
+  return chain([setZonelessFalse(), warnAboutRemovedMocks()]);
+}

--- a/packages/jest/src/schematics/migrations/v21/index.ts
+++ b/packages/jest/src/schematics/migrations/v21/index.ts
@@ -30,9 +30,11 @@ function writeJson(tree: Tree, path: string, value: JsonRecord): void {
  *
  * 1. **Zoneless default** — `zoneless` option now defaults to `true`. Apps
  *    still using zone.js change detection MUST explicitly set `zoneless: false`
- *    in `angular.json` under `architect.test.options`. This migration detects
- *    whether `@angular/core` is present and sets `zoneless: false` as a
- *    conservative default, preserving zone-based behaviour for existing apps.
+ *    in `angular.json` under `architect.test.options`. This migration scans the
+ *    workspace projects in `angular.json` for `test` targets using the
+ *    `@angular-builders/jest` builder and, where `zoneless` is not already set,
+ *    sets `zoneless: false` as a conservative default — preserving zone-based
+ *    behaviour for existing apps.
  *
  * 2. **Reduced global mocks** — `styleTransform`, `getComputedStyle`, and
  *    `doctype` mocks were removed (Jest 30's jsdom provides them natively).

--- a/packages/jest/tsconfig.schematics.json
+++ b/packages/jest/tsconfig.schematics.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/schematics",
+    "rootDir": "./src/schematics",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "ignoreDeprecations": "6.0",
+    "declaration": true,
+    "noImplicitAny": false,
+    "types": ["node"]
+  },
+  "include": ["src/schematics/**/*.ts"],
+  "exclude": ["src/schematics/**/*.spec.ts"]
+}

--- a/packages/jest/tsconfig.schematics.json
+++ b/packages/jest/tsconfig.schematics.json
@@ -5,7 +5,7 @@
     "rootDir": "./src/schematics",
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "declaration": true,
     "noImplicitAny": false,
     "types": ["node"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,6 +204,7 @@ __metadata:
     "@angular-devkit/architect": ">=0.2100.0 < 0.2200.0"
     "@angular-devkit/core": ^21.0.0
     "@angular/build": ^21.0.0
+    cpy-cli: ^7.0.0
     esbuild: 0.28.0
     jest: 30.4.2
     rimraf: ^6.0.0
@@ -225,6 +226,7 @@ __metadata:
     "@angular-devkit/build-angular": ^21.0.0
     "@angular-devkit/core": ^21.0.0
     "@angular/build": ^21.0.0
+    cpy-cli: ^7.0.0
     jest: 30.4.2
     lodash: ^4.17.15
     rimraf: ^6.0.0


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Users must manually update `angular.json` and `package.json` when adding `@angular-builders/custom-esbuild` or `@angular-builders/custom-webpack` to their project. Users upgrading `@angular-builders/jest` across major versions have no automated migration support.

Issue Number: N/A

## What is the new behavior?

Three additive schematics features. **Targeted at the next major aligned with Angular 22** (not yet released) — see "Versioning" below.

### Commit 1: `feat(custom-esbuild): add ng-add schematic`

`ng add @angular-builders/custom-esbuild` now:
- Rewrites `architect.build.builder` in `angular.json` to `@angular-builders/custom-esbuild:application`
- Adds `@angular-builders/custom-esbuild` to `devDependencies` in `package.json`
- Schedules `NodePackageInstallTask` (skippable via `--skipInstall`)

New files: `src/schematics/collection.json`, `src/schematics/ng-add/{index.ts,schema.json,schema.ts}`, `tsconfig.schematics.json`. Mirrors the jest ng-add schematic from #2240.

### Commit 2: `feat(custom-webpack): add ng-add schematic`

Same structure as commit 1, for `@angular-builders/custom-webpack`:
- Rewrites `architect.build.builder` to `@angular-builders/custom-webpack:browser`
- Adds `@angular-builders/custom-webpack` to `devDependencies`
- Schedules `NodePackageInstallTask`

### Commit 3: `feat(jest): add ng-update migration schematics v18-v21`

`ng update @angular-builders/jest` now applies migrations across the v18→v21 chain:

| Migration | Version jump | What it does |
|-----------|-------------|--------------|
| v18 | v17→v18 | Updates `tsconfig.spec.json` types from `jasmine` to `jest`; emits guidance on setup file rename |
| v19 | v18→v19 | Emits guidance on the zone.js setup change to explicit `setupZoneTestEnv()` |
| v20 | v19→v20 | No-op (no breaking changes; completes the migration chain) |
| v21 | v20→v21 | Sets `zoneless: false` in `angular.json` for projects using the jest builder (v21 defaults to `zoneless: true`); warns about removed global mocks |

New files: `src/schematics/migrations.json`, `src/schematics/migrations/{v18,v19,v20,v21}/index.ts`, `tsconfig.schematics.json`.

## Implementation notes

- All schematics compile with a separate `tsconfig.schematics.json` (CommonJS, Node moduleResolution) and are copied to `dist/schematics/` as part of each package's build.
- The custom-esbuild/custom-webpack `schema.ts` files for schematics are hand-authored (quicktype only generates the builder *option* schemas, not schematics schemas) and kept in sync manually.
- `tsconfig.schematics.json` uses `ignoreDeprecations: "6.0"` to allow `moduleResolution: Node`, required by `@angular-devkit/schematics`; the repo root tsconfig uses Node16, which is incompatible with Angular's schematics runtime.
- `custom-esbuild` and `custom-webpack` `.gitignore` add a `!src/schematics/**/schema.json` exception (those packages ignore `**/schema.json` globally because builder schemas are generated at build time).

## Versioning

The schematics are purely additive (no existing builder behaviour changes), but they are intended to land with the v22-aligned major rather than the current 21.x line, so the ng-add/ng-update surface ships together with the Angular 22 support. Should be merged after #2240 (shared `packages/jest/package.json` and jest `tsconfig.schematics.json` edits will need a rebase).

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

New schematics are purely additive. No existing builder behaviour is changed.
