### PR TITLE
fix(ci): use system Chrome for Karma, pin runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Karma uses the runner's preinstalled system Chrome (see karma.conf.js), so Puppeteer's
+# bundled Chrome is unused. Skip its download to avoid install-time failures when the
+# Chrome version is unavailable from Puppeteer's CDN or the cached binary is incomplete.
+env:
+  PUPPETEER_SKIP_DOWNLOAD: 'true'
+
 jobs:
   build:
     if: github.event_name == 'workflow_dispatch' || (!contains(github.event.head_commit.message, 'ci(release)'))
@@ -41,7 +47,6 @@ jobs:
             node_modules
             .yarn
             ~/.cache/Cypress
-            ~/.cache/puppeteer
           key: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           restore-keys: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-
       - uses: actions/cache@v5
@@ -51,14 +56,6 @@ jobs:
           key: yarn-dl-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-dl-${{ runner.os }}-
       - run: yarn --immutable
-      # Ensure Puppeteer Chrome binary is downloaded (needed for Karma tests in integration jobs)
-      # Puppeteer downloads Chrome on first use, so we trigger it here to include it in cache
-      - run: |
-          for app in examples/custom-webpack/*/; do
-            if [ -f "$app/package.json" ] && grep -q "puppeteer" "$app/package.json"; then
-              (cd "$app" && node -e "try { require('puppeteer').executablePath(); } catch(e) {}" || true)
-            fi
-          done
       # On PRs, build only affected packages unless 'ci:full' label is present.
       # On master events (push/workflow_dispatch), build all packages. (see #2026)
       - run: |
@@ -103,7 +100,6 @@ jobs:
             node_modules
             .yarn
             ~/.cache/Cypress
-            ~/.cache/puppeteer
           key: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
       - uses: actions/download-artifact@v8
@@ -149,7 +145,6 @@ jobs:
             node_modules
             .yarn
             ~/.cache/Cypress
-            ~/.cache/puppeteer
           key: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
       - uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build:
     if: github.event_name == 'workflow_dispatch' || (!contains(github.event.head_commit.message, 'ci(release)'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.discover.outputs.matrix }}
       has_tests: ${{ steps.discover.outputs.has_tests }}
@@ -87,7 +87,7 @@ jobs:
     needs: build
     if: needs.build.outputs.has_tests == 'true'
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build.outputs.matrix) }}
@@ -121,7 +121,7 @@ jobs:
   ci-pass:
     needs: [build, integration]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
@@ -129,7 +129,7 @@ jobs:
   publish:
     needs: [build, integration]
     if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       id-token: write

--- a/examples/custom-webpack/full-cycle-app/karma.conf.js
+++ b/examples/custom-webpack/full-cycle-app/karma.conf.js
@@ -2,7 +2,17 @@
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
 const path = require('path');
-process.env.CHROME_BIN = require('puppeteer').executablePath();
+const fs = require('fs');
+// Prefer the system Chrome (preinstalled and library-matched on CI runners); fall back to
+// Puppeteer's bundled Chrome for local dev. Puppeteer's bundled binary stopped launching on
+// updated CI runner images ("Cannot start ChromeHeadless"), so system Chrome is more robust.
+process.env.CHROME_BIN =
+  [
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/chromium',
+  ].find(p => fs.existsSync(p)) || require('puppeteer').executablePath();
 
 module.exports = function (config) {
   config.set({

--- a/examples/custom-webpack/sanity-app-esm/karma.conf.cjs
+++ b/examples/custom-webpack/sanity-app-esm/karma.conf.cjs
@@ -1,7 +1,14 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
-process.env.CHROME_BIN = require('puppeteer').executablePath();
+const fs = require('fs');
+// Prefer the system Chrome (preinstalled and library-matched on CI runners); fall back to
+// Puppeteer's bundled Chrome for local dev. Puppeteer's bundled binary stopped launching on
+// updated CI runner images ("Cannot start ChromeHeadless"), so system Chrome is more robust.
+process.env.CHROME_BIN =
+  ['/usr/bin/google-chrome', '/usr/bin/google-chrome-stable', '/usr/bin/chromium-browser', '/usr/bin/chromium'].find(
+    p => fs.existsSync(p)
+  ) || require('puppeteer').executablePath();
 
 module.exports = function (config) {
   config.set({

--- a/examples/custom-webpack/sanity-app/karma.conf.js
+++ b/examples/custom-webpack/sanity-app/karma.conf.js
@@ -2,7 +2,17 @@
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
 const path = require('path');
-process.env.CHROME_BIN = require('puppeteer').executablePath();
+const fs = require('fs');
+// Prefer the system Chrome (preinstalled and library-matched on CI runners); fall back to
+// Puppeteer's bundled Chrome for local dev. Puppeteer's bundled binary stopped launching on
+// updated CI runner images ("Cannot start ChromeHeadless"), so system Chrome is more robust.
+process.env.CHROME_BIN =
+  [
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/chromium',
+  ].find(p => fs.existsSync(p)) || require('puppeteer').executablePath();
 
 module.exports = function (config) {
   config.set({

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "description": "Track GitHub-hosted runner image versions (runs-on), but never auto-merge them - a runner bump can change the CI environment and must be reviewed/tested.",
+      "matchDatasources": ["github-runners"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features) — covered by the existing `custom-webpack: Karma *` integration jobs
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

All `custom-webpack: Karma *` integration jobs fail with `Cannot start ChromeHeadless` (empty stdout/stderr). Root cause: `karma.conf.js` set `CHROME_BIN = require('puppeteer').executablePath()`, pointing Karma at Puppeteer's bundled Chrome. After a GitHub hosted-runner image roll (around 2026-05-30 → 05-31), the cached/bundled Chrome no longer launches against the updated image's system libraries. The `ci.yml` "warm Puppeteer Chrome" step was already a no-op — `executablePath()` does not download Chrome in modern Puppeteer (it's fetched at install time), so nothing guaranteed a working binary.

This is environmental (master passed the same jobs on 2026-05-30 with no repo change since); it blocks every `custom-webpack` PR.

## What is the new behavior?

- `karma.conf.js` (sanity-app + full-cycle-app) prefers the runner's **preinstalled, library-matched system Chrome** (`/usr/bin/google-chrome` etc.), falling back to Puppeteer's bundled Chrome only for local dev. System Chrome stays consistent with the image, so image rolls no longer break the launcher.
- Pin CI `runs-on` to `ubuntu-24.04` (was `ubuntu-latest`) so a future `ubuntu-latest` major bump can't silently change the environment. (Note: GitHub-hosted runners still update image *contents* within a major; the system-Chrome change is what makes us resilient to that.)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Stopgap by design: Karma is removed in Angular 22 (deprecated in v20; Vitest `@angular/build:unit-test` is the replacement). The proper migration of these examples off Karma is tracked in #1928 and belongs to the v22 cycle. This change just unblocks `custom-webpack` CI in the meantime.
