### PR TITLE
fix(timestamp): annotate default export with Builder<T> to avoid TS2742

### DIFF
--- a/packages/timestamp/src/index.ts
+++ b/packages/timestamp/src/index.ts
@@ -1,5 +1,5 @@
 import { SchemaObject as TimestampBuilderSchema } from './schema';
-import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { Builder, BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { Observable, bindNodeCallback, from, of } from 'rxjs';
 import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { getSystemPath, normalize, json } from '@angular-devkit/core';
@@ -27,4 +27,9 @@ export function createTimestamp(
   );
 }
 
-export default createBuilder<json.JsonObject & TimestampBuilderSchema>(createTimestamp);
+// Explicit Builder<T> annotation (not inferred): newer @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, which makes the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const timestampBuilder: Builder<json.JsonObject & TimestampBuilderSchema> =
+  createBuilder(createTimestamp);
+export default timestampBuilder;


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features) — N/A (type-only annotation; covered by the timestamp build/integration tests)
- [x] Docs have been added / updated (for bug fixes / features) — N/A

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `@angular-builders/timestamp` package build fails under the `@angular-devkit/*` v21.2.14 dependency tree (surfaced by Renovate #2263):

```
src/index.ts:30:1 - error TS2742: The inferred type of 'default' cannot be named without a
reference to '@angular-devkit/architect/node_modules/@angular-devkit/core'. This is likely
not portable. A type annotation is necessary.
```

v21.2.14 nests a second copy of `@angular-devkit/core` under `@angular-devkit/architect`. The default export's type was **inferred** from `createBuilder(...)`, and that inferred type references the nested core copy — which TypeScript can't name portably (TS2742). Build green on 21.2.13, red on 21.2.14.

Issue Number: N/A (unblocks #2263)

## What is the new behavior?

The default export is given an **explicit** `Builder<T>` type annotation imported from `@angular-devkit/architect`, so TypeScript names the type from the public entry point and never needs to reference the nested `@angular-devkit/core` copy. No runtime/behavior change.

```ts
const timestampBuilder: Builder<json.JsonObject & TimestampBuilderSchema> =
  createBuilder(createTimestamp);
export default timestampBuilder;
```

Verified: `yarn build` in `packages/timestamp` passes. The real-world repro (the 21.2.14 nested-core tree) is validated by rebasing #2263 onto this — its `build` job should go green.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

**Unblocks Renovate #2263** (`@angular-devkit/build-angular` / `@angular/build` / `@angular/cli` 21.2.13 → 21.2.14), whose `build` job currently fails on exactly this TS2742. Merge this first, then rebase #2263.