### PR TITLE
chore(deps): bump ng-packagr to 22.0.0 in multiple-apps example

### DIFF
--- a/examples/jest/multiple-apps/package.json
+++ b/examples/jest/multiple-apps/package.json
@@ -40,7 +40,7 @@
     "jest": "30.4.2",
     "jest-environment-jsdom": "30.4.1",
     "jsdom": "29.1.1",
-    "ng-packagr": "21.2.3",
+    "ng-packagr": "22.0.0",
     "ts-node": "10.9.2",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8270,7 +8270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-colors@npm:4.1.3, ansi-colors@npm:^4.1.3":
+"ansi-colors@npm:4.1.3":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
   checksum: a9c2ec842038a1fabc7db9ece7d3177e2fe1c5dc6f0c51ecfbf5f39911427b89c00b5dc6b8bd95f82a26e9b16aaae2e83d45f060e98070ce4d1333038edceb0e
@@ -11114,7 +11114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:0.28.0":
+"esbuild@npm:0.28.0, esbuild@npm:^0.28.0":
   version: 0.28.0
   resolution: "esbuild@npm:0.28.0"
   dependencies:
@@ -15964,7 +15964,7 @@ __metadata:
     jest: 30.4.2
     jest-environment-jsdom: 30.4.1
     jsdom: 29.1.1
-    ng-packagr: 21.2.3
+    ng-packagr: 22.0.0
     rxjs: 7.8.2
     ts-node: 10.9.2
     tslib: 2.8.1
@@ -16069,20 +16069,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ng-packagr@npm:21.2.3":
-  version: 21.2.3
-  resolution: "ng-packagr@npm:21.2.3"
+"ng-packagr@npm:22.0.0":
+  version: 22.0.0
+  resolution: "ng-packagr@npm:22.0.0"
   dependencies:
     "@ampproject/remapping": ^2.3.0
     "@rollup/plugin-json": ^6.1.0
     "@rollup/wasm-node": ^4.24.0
     ajv: ^8.17.1
-    ansi-colors: ^4.1.3
     browserslist: ^4.26.0
     chokidar: ^5.0.0
     commander: ^14.0.0
     dependency-graph: ^1.0.0
-    esbuild: ^0.27.0
+    esbuild: ^0.28.0
     find-cache-directory: ^6.0.0
     injection-js: ^2.4.0
     jsonc-parser: ^3.3.1
@@ -16096,10 +16095,10 @@ __metadata:
     sass: ^1.81.0
     tinyglobby: ^0.2.12
   peerDependencies:
-    "@angular/compiler-cli": ^21.0.0 || ^21.2.0-next
+    "@angular/compiler-cli": ^22.0.0 || ^22.1.0-next.0
     tailwindcss: ^2.0.0 || ^3.0.0 || ^4.0.0
     tslib: ^2.3.0
-    typescript: ">=5.9 <6.0"
+    typescript: ">=6.0 <6.1"
   dependenciesMeta:
     rollup:
       optional: true
@@ -16108,7 +16107,7 @@ __metadata:
       optional: true
   bin:
     ng-packagr: src/cli/main.js
-  checksum: d1b5a767af99a624e953f4f16264d6fa84b706e7dc99be31716599a1e52931c606cad2f295a17759c8f7024e4df17fef37727452ac121927798c369ab257604a
+  checksum: 2c7c174924833e6652395ecf05b56095fd440b1e24b7ba7d15e1d2e66151cb5f74b13a426a3f9169d628a136342632b2fba4f103da6135fca94cbd9f6f58b942
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features) — covered by the existing `jest: multi-project library` integration test
- [ ] Docs have been added / updated (for bug fixes / features) — N/A

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe: dependency bump in a test-fixture example
```

## What is the current behavior?

`examples/jest/multiple-apps` still pins `ng-packagr` at `21.2.3` while the rest of its toolchain is on the Angular `22.0.0-rc.2` line — a full major behind. This is the v22 counterpart of Renovate #2269 (which targeted `master` and was closed; the bump belongs on `release/v22`).

Issue Number: N/A (replaces #2269)

## What is the new behavior?

`ng-packagr` bumped to `22.0.0` (the only published 22.x; no RC line). Its peer `typescript >=6.0 <6.1` is satisfied by the example's `6.0.3`. Aligns the major with the rest of the v22 toolchain and reduces the current version skew.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

Test-fixture dependency only — not a published package.

## Other information

Targets `release/v22`. `ci:full` label applied so the `jest: multi-project library` integration test (which builds this example's library via ng-packagr) actually runs — an example-only change can otherwise be skipped by Turbo's affected-package filter.