### PR TITLE
fix(builders): annotate builder default exports with Builder<T> to avoid TS2742

### DIFF
--- a/packages/bazel/src/index.ts
+++ b/packages/bazel/src/index.ts
@@ -1,4 +1,4 @@
-import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { Builder, BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import type { JsonObject } from '@angular-devkit/core';
 import { getNativeBinary as bazeliskBin } from '@bazel/bazelisk/bazelisk';
 import { getNativeBinary as ibazelBin } from '@bazel/ibazel';
@@ -35,4 +35,8 @@ async function _bazelBuilder(
   }
 }
 
-export default createBuilder(_bazelBuilder);
+// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const builder: Builder<JsonObject & Schema> = createBuilder(_bazelBuilder);
+export default builder;

--- a/packages/custom-esbuild/src/application/index.ts
+++ b/packages/custom-esbuild/src/application/index.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import { BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { Builder, BuilderContext, createBuilder } from '@angular-devkit/architect';
 import { buildApplication } from '@angular/build';
 import { getSystemPath, json, normalize } from '@angular-devkit/core';
 import { defer, switchMap } from 'rxjs';
@@ -38,6 +38,10 @@ export function buildCustomEsbuildApplication(
   }).pipe(switchMap(extensions => buildApplication(options, context, extensions)));
 }
 
-export default createBuilder<json.JsonObject & CustomEsbuildApplicationSchema>(
-  buildCustomEsbuildApplication
-);
+// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const builder: Builder<json.JsonObject & CustomEsbuildApplicationSchema> = createBuilder<
+  json.JsonObject & CustomEsbuildApplicationSchema
+>(buildCustomEsbuildApplication);
+export default builder;

--- a/packages/custom-esbuild/src/dev-server/index.ts
+++ b/packages/custom-esbuild/src/dev-server/index.ts
@@ -1,5 +1,10 @@
 import * as path from 'node:path';
-import { BuilderContext, createBuilder, targetFromTargetString } from '@angular-devkit/architect';
+import {
+  Builder,
+  BuilderContext,
+  createBuilder,
+  targetFromTargetString,
+} from '@angular-devkit/architect';
 import {
   DevServerBuilderOptions,
   DevServerBuilderOutput,
@@ -79,6 +84,10 @@ export function executeCustomDevServerBuilder(
   );
 }
 
-export default createBuilder<DevServerBuilderOptions & json.JsonObject>(
-  executeCustomDevServerBuilder
-);
+// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const builder: Builder<DevServerBuilderOptions & json.JsonObject> = createBuilder<
+  DevServerBuilderOptions & json.JsonObject
+>(executeCustomDevServerBuilder);
+export default builder;

--- a/packages/custom-esbuild/src/unit-test/index.ts
+++ b/packages/custom-esbuild/src/unit-test/index.ts
@@ -1,5 +1,10 @@
 import * as path from 'node:path';
-import { BuilderContext, createBuilder, targetFromTargetString } from '@angular-devkit/architect';
+import {
+  Builder,
+  BuilderContext,
+  createBuilder,
+  targetFromTargetString,
+} from '@angular-devkit/architect';
 import { executeUnitTestBuilder, UnitTestBuilderOptions } from '@angular/build';
 import { getSystemPath, json, normalize } from '@angular-devkit/core';
 import { from, switchMap } from 'rxjs';
@@ -52,6 +57,10 @@ export function executeCustomEsbuildUnitTestBuilder(
   );
 }
 
-export default createBuilder<json.JsonObject & CustomEsbuildUnitTestSchema>(
-  executeCustomEsbuildUnitTestBuilder
-);
+// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const builder: Builder<json.JsonObject & CustomEsbuildUnitTestSchema> = createBuilder<
+  json.JsonObject & CustomEsbuildUnitTestSchema
+>(executeCustomEsbuildUnitTestBuilder);
+export default builder;

--- a/packages/custom-webpack/src/browser/index.ts
+++ b/packages/custom-webpack/src/browser/index.ts
@@ -1,4 +1,4 @@
-import { BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { Builder, BuilderContext, createBuilder } from '@angular-devkit/architect';
 import { BrowserBuilderOptions, executeBrowserBuilder } from '@angular-devkit/build-angular';
 import { json } from '@angular-devkit/core';
 import { getTransforms } from '../transform-factories';
@@ -12,6 +12,10 @@ export const buildCustomWebpackBrowser = (
 ): ReturnType<typeof executeBrowserBuilder> =>
   executeBrowserBuilder(options, context, getTransforms(options, context));
 
-export default createBuilder<json.JsonObject & CustomWebpackBrowserSchema>(
-  buildCustomWebpackBrowser
-);
+// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const builder: Builder<json.JsonObject & CustomWebpackBrowserSchema> = createBuilder<
+  json.JsonObject & CustomWebpackBrowserSchema
+>(buildCustomWebpackBrowser);
+export default builder;

--- a/packages/custom-webpack/src/dev-server/index.ts
+++ b/packages/custom-webpack/src/dev-server/index.ts
@@ -1,8 +1,12 @@
-import { createBuilder } from '@angular-devkit/architect';
+import { Builder, createBuilder } from '@angular-devkit/architect';
 import { DevServerBuilderOptions, executeDevServerBuilder } from '@angular-devkit/build-angular';
 import { json } from '@angular-devkit/core';
 import { executeBrowserBasedBuilder } from '../generic-browser-builder';
 
-export default createBuilder<DevServerBuilderOptions & json.JsonObject>(
-  executeBrowserBasedBuilder(executeDevServerBuilder)
-);
+// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const builder: Builder<DevServerBuilderOptions & json.JsonObject> = createBuilder<
+  DevServerBuilderOptions & json.JsonObject
+>(executeBrowserBasedBuilder(executeDevServerBuilder));
+export default builder;

--- a/packages/custom-webpack/src/extract-i18n/index.ts
+++ b/packages/custom-webpack/src/extract-i18n/index.ts
@@ -1,4 +1,4 @@
-import { createBuilder } from '@angular-devkit/architect';
+import { Builder, createBuilder } from '@angular-devkit/architect';
 import {
   executeExtractI18nBuilder,
   ExtractI18nBuilderOptions,
@@ -9,6 +9,10 @@ import { executeBrowserBasedBuilder } from '../generic-browser-builder';
 type CustomWebpackI18nSchema = ExtractI18nBuilderOptions &
   json.JsonObject & { buildTarget: string };
 
-export default createBuilder<CustomWebpackI18nSchema>(
+// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const builder: Builder<CustomWebpackI18nSchema> = createBuilder<CustomWebpackI18nSchema>(
   executeBrowserBasedBuilder(executeExtractI18nBuilder)
 );
+export default builder;

--- a/packages/custom-webpack/src/karma/index.ts
+++ b/packages/custom-webpack/src/karma/index.ts
@@ -2,7 +2,7 @@
  * Created by Evgeny Barabanov on 05/10/2018.
  */
 
-import { BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { Builder, BuilderContext, createBuilder } from '@angular-devkit/architect';
 import { executeKarmaBuilder, KarmaBuilderOptions } from '@angular-devkit/build-angular';
 import { json } from '@angular-devkit/core';
 import { customWebpackConfigTransformFactory } from '../transform-factories';
@@ -18,6 +18,10 @@ export const buildCustomWebpackKarma = (
     webpackConfiguration: customWebpackConfigTransformFactory(options, context),
   });
 
-export default createBuilder<json.JsonObject & CustomWebpackKarmaBuildSchema>(
-  buildCustomWebpackKarma
-);
+// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const builder: Builder<json.JsonObject & CustomWebpackKarmaBuildSchema> = createBuilder<
+  json.JsonObject & CustomWebpackKarmaBuildSchema
+>(buildCustomWebpackKarma);
+export default builder;

--- a/packages/custom-webpack/src/server/index.ts
+++ b/packages/custom-webpack/src/server/index.ts
@@ -2,7 +2,7 @@
  * Created by Evgeny Barabanov on 28/06/2018.
  */
 
-import { BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { Builder, BuilderContext, createBuilder } from '@angular-devkit/architect';
 import { executeServerBuilder, ServerBuilderOptions } from '@angular-devkit/build-angular';
 import { json } from '@angular-devkit/core';
 import { customWebpackConfigTransformFactory } from '../transform-factories';
@@ -18,4 +18,10 @@ export const buildCustomWebpackServer = (
     webpackConfiguration: customWebpackConfigTransformFactory(options, context),
   });
 
-export default createBuilder<json.JsonObject & CustomWebpackServerSchema>(buildCustomWebpackServer);
+// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const builder: Builder<json.JsonObject & CustomWebpackServerSchema> = createBuilder<
+  json.JsonObject & CustomWebpackServerSchema
+>(buildCustomWebpackServer);
+export default builder;

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -1,4 +1,4 @@
-import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { Builder, BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { normalize, Path, schema, json, workspaces } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import { run } from 'jest';
@@ -70,4 +70,10 @@ export function runJest(
   return from(runJestCLI()).pipe(map(() => ({ success: true })));
 }
 
-export default createBuilder<JestBuilderSchema & json.JsonObject>(runJest);
+// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
+// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
+// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
+const builder: Builder<JestBuilderSchema & json.JsonObject> = createBuilder<
+  JestBuilderSchema & json.JsonObject
+>(runJest);
+export default builder;


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features) — N/A (type-only annotation; covered by each package's build + integration tests)
- [x] Docs have been added / updated (for bug fixes / features) — N/A

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Under the `@angular-devkit/*` 21.2.14 dependency tree (surfaced by Renovate #2263), the builder packages fail to build with TS2742, e.g.:

```
src/index.ts: error TS2742: The inferred type of 'default' cannot be named without a
reference to '@angular-devkit/architect/node_modules/@angular-devkit/core'. ...
```

The 21.2.14 lock resolves **four** `@angular-devkit/core` versions. `@angular-devkit/architect@0.2102.14` pins `core@21.2.14` exactly, while the builder packages depend on `core` by range and resolve to a different patch. TypeScript then sees two `core` identities and cannot name the **inferred** `Builder<T>` return type of `createBuilder(...)` for each default export (TS2742). #2275 already fixed `timestamp`; with that resolved the build advances and hits the same issue in `bazel`, then would hit `jest`, `custom-esbuild`, and `custom-webpack`.

Issue Number: N/A (unblocks #2263)

## What is the new behavior?

Every builder default export is given an **explicit** `Builder<T>` annotation imported from `@angular-devkit/architect`, so the emitted type names `Builder` from the public entry point and never references the nested `@angular-devkit/core` copy. No runtime/behavior change — type-only.

10 builder exports annotated across `bazel`, `jest`, `custom-esbuild` (application, dev-server, unit-test), and `custom-webpack` (browser, dev-server, extract-i18n, karma, server) — the same pattern as #2275.

This is a permanent fix (independent of dep-tree shape), so it also inoculates the v22 line against any future recurrence; it rides into `release/v22` via the planned `master → release/v22` sync.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

**Unblocks Renovate #2263** (21.2.13 → 21.2.14). Validation: this PR's CI builds against master's 21.2.13 deps (confirms the annotations don't break the build); the TS2742 fix itself is confirmed by #2263's `build` going green once rebased onto a master that includes this.