### PR TITLE
revert: remove redundant TS2742 builder annotations (#2275, #2278)

### DIFF
--- a/packages/bazel/src/index.ts
+++ b/packages/bazel/src/index.ts
@@ -1,4 +1,4 @@
-import { Builder, BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import type { JsonObject } from '@angular-devkit/core';
 import { getNativeBinary as bazeliskBin } from '@bazel/bazelisk/bazelisk';
 import { getNativeBinary as ibazelBin } from '@bazel/ibazel';
@@ -35,8 +35,4 @@ async function _bazelBuilder(
   }
 }
 
-// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const builder: Builder<JsonObject & Schema> = createBuilder(_bazelBuilder);
-export default builder;
+export default createBuilder(_bazelBuilder);

--- a/packages/custom-esbuild/src/application/index.ts
+++ b/packages/custom-esbuild/src/application/index.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import { Builder, BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { BuilderContext, createBuilder } from '@angular-devkit/architect';
 import { buildApplication } from '@angular/build';
 import { getSystemPath, json, normalize } from '@angular-devkit/core';
 import { defer, switchMap } from 'rxjs';
@@ -38,10 +38,6 @@ export function buildCustomEsbuildApplication(
   }).pipe(switchMap(extensions => buildApplication(options, context, extensions)));
 }
 
-// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const builder: Builder<json.JsonObject & CustomEsbuildApplicationSchema> = createBuilder<
-  json.JsonObject & CustomEsbuildApplicationSchema
->(buildCustomEsbuildApplication);
-export default builder;
+export default createBuilder<json.JsonObject & CustomEsbuildApplicationSchema>(
+  buildCustomEsbuildApplication
+);

--- a/packages/custom-esbuild/src/dev-server/index.ts
+++ b/packages/custom-esbuild/src/dev-server/index.ts
@@ -1,10 +1,5 @@
 import * as path from 'node:path';
-import {
-  Builder,
-  BuilderContext,
-  createBuilder,
-  targetFromTargetString,
-} from '@angular-devkit/architect';
+import { BuilderContext, createBuilder, targetFromTargetString } from '@angular-devkit/architect';
 import {
   DevServerBuilderOptions,
   DevServerBuilderOutput,
@@ -84,10 +79,6 @@ export function executeCustomDevServerBuilder(
   );
 }
 
-// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const builder: Builder<DevServerBuilderOptions & json.JsonObject> = createBuilder<
-  DevServerBuilderOptions & json.JsonObject
->(executeCustomDevServerBuilder);
-export default builder;
+export default createBuilder<DevServerBuilderOptions & json.JsonObject>(
+  executeCustomDevServerBuilder
+);

--- a/packages/custom-esbuild/src/unit-test/index.ts
+++ b/packages/custom-esbuild/src/unit-test/index.ts
@@ -1,10 +1,5 @@
 import * as path from 'node:path';
-import {
-  Builder,
-  BuilderContext,
-  createBuilder,
-  targetFromTargetString,
-} from '@angular-devkit/architect';
+import { BuilderContext, createBuilder, targetFromTargetString } from '@angular-devkit/architect';
 import { executeUnitTestBuilder, UnitTestBuilderOptions } from '@angular/build';
 import { getSystemPath, json, normalize } from '@angular-devkit/core';
 import { from, switchMap } from 'rxjs';
@@ -57,10 +52,6 @@ export function executeCustomEsbuildUnitTestBuilder(
   );
 }
 
-// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const builder: Builder<json.JsonObject & CustomEsbuildUnitTestSchema> = createBuilder<
-  json.JsonObject & CustomEsbuildUnitTestSchema
->(executeCustomEsbuildUnitTestBuilder);
-export default builder;
+export default createBuilder<json.JsonObject & CustomEsbuildUnitTestSchema>(
+  executeCustomEsbuildUnitTestBuilder
+);

--- a/packages/custom-webpack/src/browser/index.ts
+++ b/packages/custom-webpack/src/browser/index.ts
@@ -1,4 +1,4 @@
-import { Builder, BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { BuilderContext, createBuilder } from '@angular-devkit/architect';
 import { BrowserBuilderOptions, executeBrowserBuilder } from '@angular-devkit/build-angular';
 import { json } from '@angular-devkit/core';
 import { getTransforms } from '../transform-factories';
@@ -12,10 +12,6 @@ export const buildCustomWebpackBrowser = (
 ): ReturnType<typeof executeBrowserBuilder> =>
   executeBrowserBuilder(options, context, getTransforms(options, context));
 
-// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const builder: Builder<json.JsonObject & CustomWebpackBrowserSchema> = createBuilder<
-  json.JsonObject & CustomWebpackBrowserSchema
->(buildCustomWebpackBrowser);
-export default builder;
+export default createBuilder<json.JsonObject & CustomWebpackBrowserSchema>(
+  buildCustomWebpackBrowser
+);

--- a/packages/custom-webpack/src/dev-server/index.ts
+++ b/packages/custom-webpack/src/dev-server/index.ts
@@ -1,12 +1,8 @@
-import { Builder, createBuilder } from '@angular-devkit/architect';
+import { createBuilder } from '@angular-devkit/architect';
 import { DevServerBuilderOptions, executeDevServerBuilder } from '@angular-devkit/build-angular';
 import { json } from '@angular-devkit/core';
 import { executeBrowserBasedBuilder } from '../generic-browser-builder';
 
-// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const builder: Builder<DevServerBuilderOptions & json.JsonObject> = createBuilder<
-  DevServerBuilderOptions & json.JsonObject
->(executeBrowserBasedBuilder(executeDevServerBuilder));
-export default builder;
+export default createBuilder<DevServerBuilderOptions & json.JsonObject>(
+  executeBrowserBasedBuilder(executeDevServerBuilder)
+);

--- a/packages/custom-webpack/src/extract-i18n/index.ts
+++ b/packages/custom-webpack/src/extract-i18n/index.ts
@@ -1,4 +1,4 @@
-import { Builder, createBuilder } from '@angular-devkit/architect';
+import { createBuilder } from '@angular-devkit/architect';
 import {
   executeExtractI18nBuilder,
   ExtractI18nBuilderOptions,
@@ -9,10 +9,6 @@ import { executeBrowserBasedBuilder } from '../generic-browser-builder';
 type CustomWebpackI18nSchema = ExtractI18nBuilderOptions &
   json.JsonObject & { buildTarget: string };
 
-// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const builder: Builder<CustomWebpackI18nSchema> = createBuilder<CustomWebpackI18nSchema>(
+export default createBuilder<CustomWebpackI18nSchema>(
   executeBrowserBasedBuilder(executeExtractI18nBuilder)
 );
-export default builder;

--- a/packages/custom-webpack/src/karma/index.ts
+++ b/packages/custom-webpack/src/karma/index.ts
@@ -2,7 +2,7 @@
  * Created by Evgeny Barabanov on 05/10/2018.
  */
 
-import { Builder, BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { BuilderContext, createBuilder } from '@angular-devkit/architect';
 import { executeKarmaBuilder, KarmaBuilderOptions } from '@angular-devkit/build-angular';
 import { json } from '@angular-devkit/core';
 import { customWebpackConfigTransformFactory } from '../transform-factories';
@@ -18,10 +18,6 @@ export const buildCustomWebpackKarma = (
     webpackConfiguration: customWebpackConfigTransformFactory(options, context),
   });
 
-// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const builder: Builder<json.JsonObject & CustomWebpackKarmaBuildSchema> = createBuilder<
-  json.JsonObject & CustomWebpackKarmaBuildSchema
->(buildCustomWebpackKarma);
-export default builder;
+export default createBuilder<json.JsonObject & CustomWebpackKarmaBuildSchema>(
+  buildCustomWebpackKarma
+);

--- a/packages/custom-webpack/src/server/index.ts
+++ b/packages/custom-webpack/src/server/index.ts
@@ -2,7 +2,7 @@
  * Created by Evgeny Barabanov on 28/06/2018.
  */
 
-import { Builder, BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { BuilderContext, createBuilder } from '@angular-devkit/architect';
 import { executeServerBuilder, ServerBuilderOptions } from '@angular-devkit/build-angular';
 import { json } from '@angular-devkit/core';
 import { customWebpackConfigTransformFactory } from '../transform-factories';
@@ -18,10 +18,4 @@ export const buildCustomWebpackServer = (
     webpackConfiguration: customWebpackConfigTransformFactory(options, context),
   });
 
-// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const builder: Builder<json.JsonObject & CustomWebpackServerSchema> = createBuilder<
-  json.JsonObject & CustomWebpackServerSchema
->(buildCustomWebpackServer);
-export default builder;
+export default createBuilder<json.JsonObject & CustomWebpackServerSchema>(buildCustomWebpackServer);

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -1,4 +1,4 @@
-import { Builder, BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { normalize, Path, schema, json, workspaces } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import { run } from 'jest';
@@ -70,10 +70,4 @@ export function runJest(
   return from(runJestCLI()).pipe(map(() => ({ success: true })));
 }
 
-// Explicit Builder<T> annotation (not inferred): some @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, making the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const builder: Builder<JestBuilderSchema & json.JsonObject> = createBuilder<
-  JestBuilderSchema & json.JsonObject
->(runJest);
-export default builder;
+export default createBuilder<JestBuilderSchema & json.JsonObject>(runJest);

--- a/packages/timestamp/src/index.ts
+++ b/packages/timestamp/src/index.ts
@@ -1,5 +1,5 @@
 import { SchemaObject as TimestampBuilderSchema } from './schema';
-import { Builder, BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { Observable, bindNodeCallback, from, of } from 'rxjs';
 import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { getSystemPath, normalize, json } from '@angular-devkit/core';
@@ -27,9 +27,4 @@ export function createTimestamp(
   );
 }
 
-// Explicit Builder<T> annotation (not inferred): newer @angular-devkit dep trees nest a second
-// copy of @angular-devkit/core under @angular-devkit/architect, which makes the inferred default
-// export type non-portable (TS2742). Naming the type from @angular-devkit/architect avoids it.
-const timestampBuilder: Builder<json.JsonObject & TimestampBuilderSchema> =
-  createBuilder(createTimestamp);
-export default timestampBuilder;
+export default createBuilder<json.JsonObject & TimestampBuilderSchema>(createTimestamp);


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features) — N/A (revert; covered by existing build + integration)
- [x] Docs have been added / updated (for bug fixes / features) — N/A

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

#2275 and #2278 added explicit `Builder<T>` annotations to every builder default export to work around TS2742. Those errors were **symptoms** of the real root cause: Renovate's #2263 widened the `@angular-devkit/architect` range to `< 0.2201.0`, pulling a **v22** architect + core into the v21 tree (and leaving stale 21.0.x devkit copies). That has now been fixed at the source in #2263 (architect range restored to `>=0.2100.0 < 0.2200.0` + `yarn dedupe` collapsing devkit packages to a single `21.2.14`/`0.2102.14`).

Issue Number: N/A

## What is the new behavior?

Reverts both annotation commits. With the dependency tree now consistent (single architect/core), the inferred default-export types are nameable again — no TS2742, no annotations needed. master was always green without them; they only ever appeared on the broken #2263 tree.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

Type-only revert; no runtime change.

## Other information

The revert PR's own CI (master @ 21.2.14, correct deps, no annotations) is the proof that the annotations were redundant.