### PR TITLE
chore(renovate): hold @angular-devkit/architect at current Angular major

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,17 @@
       "matchPackageNames": ["typescript"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "@angular-devkit/architect uses Angular's 0.{major}{minor}.{patch} scheme (0.2102 = v21.2). Renovate treats the leading 0 as the major, so a v21->v22 bump (0.2102 -> 0.2200) looks like a minor and slips past major-hold rules — it gets bundled into routine patch PRs and fragments the dep tree (see #2263). Reinterpret the real Angular major via regex versioning.",
+      "matchPackageNames": ["@angular-devkit/architect"],
+      "versioning": "regex:^0\\.(?<major>\\d{2})(?<minor>\\d{2})\\.(?<patch>\\d+)$"
+    },
+    {
+      "description": "Hold @angular-devkit/architect Angular-major bumps until the builders move that major — same policy as the TypeScript-major hold above. See #2263.",
+      "matchPackageNames": ["@angular-devkit/architect"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features) — N/A (CI config; validated with `renovate-config-validator`)
- [x] Docs have been added / updated (for bug fixes / features) — N/A

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`@angular-devkit/architect` uses Angular's `0.{major}{minor}.{patch}` scheme (`0.2102.14` = Angular 21.2.14). Renovate treats the leading `0` as the semver major, so a v21→v22 bump (`0.2102 → 0.2200`) is classified as a **minor** — it slips past major-hold/separation, gets bundled into routine patch PRs, and bumps architect across the Angular major. That pulled a v22 architect into the v21 tree in #2263, fragmenting `@angular-devkit/*` and breaking `custom-webpack`/`custom-esbuild` builds (TS2345/TS2742).

Issue Number: N/A (follow-up to #2263)

## What is the new behavior?

Two `packageRules` for `@angular-devkit/architect`, mirroring the existing TypeScript-major hold:

1. **Regex versioning** — reinterprets the real Angular major: `regex:^0\.(?<major>\d{2})(?<minor>\d{2})\.(?<patch>\d+)$`, so `0.2102.14` → major 21 / minor 2 / patch 14 and `0.2200.0` → major 22. Patch/minor updates within an Angular major still flow normally.
2. **Major hold** (`matchUpdateTypes: ["major"], enabled: false`) — a v21→v22 architect bump is now classified major and held until the builders deliberately move that major, exactly like `21.x → 22.x` Angular packages and the TypeScript-major hold.

Validated with `renovate-config-validator` ("Config validated successfully").

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Prevents the #2263 class of dependency-tree fragmentation from recurring on future Angular bumps. When the builders graduate to the next Angular major, drop/raise this hold deliberately (same manual gate already used for majors).