### PR TITLE
feat!: replace ts-node with jiti for loading TypeScript modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,8 @@ Lerna-Lite manages versioning and publishing. Packages use **independent version
 
 **MUST NEVER:** Ship a breaking dependency update (e.g., a new webpack-merge major) as a minor version of a builder package. Breaking changes must wait for the next major version aligned with Angular. (Source: SME interview, Jeb, 2026-02-16)
 
+**MUST:** Any PR introducing a breaking change that requires changes to a user's project (code, config, npm scripts, dependencies, or workspace files) MUST ship the corresponding `ng update` migration schematic in the same PR — users should never have to perform the migration by hand. The affected builder packages expose `ng update` via their `migrations.json` (`ng-update` field in `package.json`); shared migration logic lives in `@angular-builders/common/schematics` (e.g. `migrateToJitiLoader`) and per-package migrations delegate to it. Automate everything that can be applied safely; only `logger.warn` for changes that cannot be made automatically without risking the user's build.
+
 **MUST NEVER:** Use `ci(release)` in commit messages outside of the automated publish process -- it causes CI to skip the entire pipeline.
 
 **MUST:** When creating a pull request, read `.github/PULL_REQUEST_TEMPLATE.md` and use its structure for the PR body. Fill in all sections: PR checklist, PR type, current behavior, new behavior, and breaking change flag.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ The two primary packages -- `custom-esbuild` and `custom-webpack` -- wrap Angula
 ### Package Dependency Graph
 
 ```
-custom-esbuild ──> common ──> ts-node, tsconfig-paths
+custom-esbuild ──> common ──> jiti, get-tsconfig
 custom-webpack ──> common, @angular/build (IndexHtmlTransform type)
 jest ──────────> common
 bazel            (standalone -- no common dependency)

--- a/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
@@ -4,11 +4,8 @@
   "type": "module",
   "scripts": {
     "start": "ng serve",
-    "start-ts": "ng serve",
     "build": "ng build",
-    "build-ts": "ng build",
     "test": "ng test",
-    "test-ts": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "cypress:open": "cypress open",

--- a/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
@@ -4,11 +4,11 @@
   "type": "module",
   "scripts": {
     "start": "ng serve",
-    "start-ts": "TS_NODE_PROJECT=tsconfig.app.json NODE_OPTIONS='--loader ts-node/esm' ng serve",
+    "start-ts": "ng serve",
     "build": "ng build",
-    "build-ts": "TS_NODE_PROJECT=tsconfig.app.json NODE_OPTIONS='--loader ts-node/esm' ng build",
+    "build-ts": "ng build",
     "test": "ng test",
-    "test-ts": "TS_NODE_PROJECT=tsconfig.spec.json NODE_OPTIONS='--loader ts-node/esm' ng test",
+    "test-ts": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "cypress:open": "cypress open",
@@ -41,7 +41,6 @@
     "cypress": "15.16.0",
     "eslint": "10.4.1",
     "puppeteer": "25.1.0",
-    "ts-node": "10.9.2",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.0",
     "vitest": "4.1.7"

--- a/examples/custom-esbuild/sanity-esbuild-app/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app/package.json
@@ -38,7 +38,6 @@
     "cypress": "15.16.0",
     "eslint": "10.4.1",
     "puppeteer": "25.1.0",
-    "ts-node": "10.9.2",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.0",
     "vitest": "4.1.7"

--- a/examples/custom-webpack/full-cycle-app/extra-webpack.config.json-import.ts
+++ b/examples/custom-webpack/full-cycle-app/extra-webpack.config.json-import.ts
@@ -1,8 +1,6 @@
 import { Configuration } from 'webpack';
-// Importing a JSON file from a TypeScript webpack config.
-// Requires resolveJsonModule: true to be set — either in the user's tsconfig or
-// injected by the builder's ts-node registration.
-// When moduleResolution is 'node' and resolveJsonModule is absent, ts-node throws TS2732.
+// Importing a JSON file from a TypeScript webpack config. The builder loads this
+// file with jiti, which must resolve JSON imports.
 // Regression test for: https://github.com/just-jeb/angular-builders/issues/816
 import * as pkg from './package.json';
 

--- a/examples/custom-webpack/full-cycle-app/package.json
+++ b/examples/custom-webpack/full-cycle-app/package.json
@@ -45,7 +45,6 @@
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.2.0",
     "puppeteer": "25.1.0",
-    "ts-node": "10.9.2",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.0"
   }

--- a/examples/custom-webpack/sanity-app-esm/package.json
+++ b/examples/custom-webpack/sanity-app-esm/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "start-ts": "TS_NODE_PROJECT=tsconfig.app.json NODE_OPTIONS='--loader ts-node/esm' ng serve",
+    "start-ts": "ng serve",
     "build": "ng build",
-    "build-ts": "TS_NODE_PROJECT=tsconfig.app.json NODE_OPTIONS='--loader ts-node/esm' ng build",
+    "build-ts": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "e2e": "ng e2e",

--- a/examples/custom-webpack/sanity-app-esm/package.json
+++ b/examples/custom-webpack/sanity-app-esm/package.json
@@ -5,9 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "start-ts": "ng serve",
     "build": "ng build",
-    "build-ts": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "e2e": "ng e2e",

--- a/examples/custom-webpack/sanity-app/extra-webpack.config.ts
+++ b/examples/custom-webpack/sanity-app/extra-webpack.config.ts
@@ -1,6 +1,5 @@
 import { Configuration } from 'webpack';
-// JSON import: verifies that ts-node is registered with resolveJsonModule:true (regression for #816).
-// Without the fix, this fails with TS2307 when the project tsconfig lacks resolveJsonModule.
+// JSON import from a TypeScript webpack config, loaded via jiti (regression for #816).
 import { name } from './package.json';
 
 export default {

--- a/examples/custom-webpack/sanity-app/package.json
+++ b/examples/custom-webpack/sanity-app/package.json
@@ -44,7 +44,6 @@
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.2.0",
     "puppeteer": "25.1.0",
-    "ts-node": "10.9.2",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.0"
   }

--- a/examples/jest/multiple-apps/package.json
+++ b/examples/jest/multiple-apps/package.json
@@ -41,7 +41,6 @@
     "jest-environment-jsdom": "30.4.1",
     "jsdom": "29.1.1",
     "ng-packagr": "22.0.0",
-    "ts-node": "10.9.2",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.0"
   }

--- a/examples/jest/simple-app/package.json
+++ b/examples/jest/simple-app/package.json
@@ -45,7 +45,6 @@
     "jest-environment-jsdom": "30.4.1",
     "jest-junit": "17.0.0",
     "jsdom": "29.1.1",
-    "ts-node": "10.9.2",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.0"
   }

--- a/examples/timestamp/package.json
+++ b/examples/timestamp/package.json
@@ -45,7 +45,6 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.2.0",
-    "ts-node": "10.9.2",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.0"
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/lodash": "^4.14.118",
     "@types/node": "^24.0.0",
     "husky": "^9.0.0",
+    "jiti": "^2.7.0",
     "lint-staged": "^17.0.0",
     "lodash": "^4.17.15",
     "prettier": "^3.0.0",

--- a/packages/common/.gitignore
+++ b/packages/common/.gitignore
@@ -15,3 +15,6 @@ dist
 *.js
 !karma.conf.js
 *.js.map
+
+# Test fixtures for loadModule (not build output)
+!src/load-module.fixtures/**/*.js

--- a/packages/common/AGENTS.md
+++ b/packages/common/AGENTS.md
@@ -4,12 +4,12 @@
 
 ## At a Glance
 
-|                  |                                                                                                                                                                                  |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Type**         | Shared Kernel                                                                                                                                                                    |
-| **Owns**         | CJS/ESM/TS module loading with ts-node registration, package path resolution. Scope may grow if common patterns emerge across builders. (Source: SME interview, Jeb, 2026-02-16) |
-| **Does NOT own** | Builder logic, schema merging, CLI integration                                                                                                                                   |
-| **Users**        | `custom-esbuild`, `custom-webpack`, `jest` (via `workspace:*` dependency)                                                                                                        |
+|                  |                                                                                                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Type**         | Shared Kernel                                                                                                                                                   |
+| **Owns**         | CJS/ESM/TS module loading via jiti, package path resolution. Scope may grow if common patterns emerge across builders. (Source: SME interview, Jeb, 2026-02-16) |
+| **Does NOT own** | Builder logic, schema merging, CLI integration                                                                                                                  |
+| **Users**        | `custom-esbuild`, `custom-webpack`, `jest` (via `workspace:*` dependency)                                                                                       |
 
 ## Navigation
 
@@ -21,19 +21,19 @@
 ## Entry Points & Contracts
 
 - `loadModule<T>(modulePath, tsConfig, logger): Promise<T>` -- Loads a user-provided module (plugin, config, transformer) regardless of format.
-  - **Guarantees:** Handles four extension cases (see `src/load-module.ts` lines 83-122): `.mjs` (ESM via dynamic import), `.cjs` (CJS via `require`), `.ts` (TypeScript via ts-node, with ESM fallback on `ERR_REQUIRE_ESM`), and a default case for `.js` and all other extensions (try CJS first, fall back to ESM on `ERR_REQUIRE_ESM`). For `.ts` and `.js` files, unwraps default exports: `require(path).default || require(path)`. (Source: code investigation, 2026-02-16)
-  - **Does NOT handle:** `.jsx`, `.tsx`, `.mts`, `.cts` extensions. JSON files are not explicitly handled but may work through Node's native `require()`. (Source: code investigation, 2026-02-16)
-  - **Requires:** Absolute `modulePath`. A valid `tsConfig` path (used for ts-node registration). An Angular `LoggerApi` instance.
+  - **Guarantees:** Loads `.ts`, `.mts`, `.cts`, `.js`, `.mjs`, and `.cjs` uniformly via [jiti](https://github.com/unjs/jiti) (`jiti.import`). TypeScript is **transpiled, not type-checked**. Default exports are unwrapped via jiti's `interopDefault` (`mod.default ?? mod`): a single default is returned; a nested `{ default: ... }` is preserved. TypeScript path aliases (`baseUrl`/`paths`) are resolved from the passed `tsConfig`. (Source: code investigation, 2026-06-07)
+  - **Does NOT handle:** `.jsx`/`.tsx`. Build-time type-checking (run `tsc --noEmit` separately). (Source: code investigation, 2026-06-07)
+  - **Requires:** Absolute `modulePath`. A `tsConfig` path (used for path-alias resolution). An Angular `LoggerApi` instance (retained for API compatibility; currently unused). (Source: code investigation, 2026-06-07)
 
 - `resolvePackagePath(packageName, subPath): string` -- Resolves a file path within an installed npm package by locating its `package.json` first.
   - **Guarantees:** Returns the absolute joined path.
   - **Requires:** The package must be installed and resolvable via `require.resolve`.
 
-Enforcement: All user-supplied module loading across the monorepo MUST go through `loadModule`. Direct `require()` or `import()` of user config files bypasses ts-node registration and ESM handling.
+Enforcement: All user-supplied module loading across the monorepo MUST go through `loadModule`. Direct `require()` or `import()` of user config files bypasses jiti's TypeScript transpilation and ESM/CJS interop.
 
 ## Invariants
 
-**MUST:** ts-node is registered at most once per process. A second call with a different `tsConfig` logs a warning and is silently skipped -- the first registration wins. Registering with the wrong tsconfig first breaks everything. There is a known open issue related to this edge case. (Source: SME interview, Jeb, 2026-02-16)
+**MUST:** Each distinct `tsConfig` gets its own isolated jiti instance (cached by tsconfig path). Loads with different tsconfigs do not interfere -- there is no process-global "first tsconfig wins" registration (the old ts-node limitation, now removed). (Source: code investigation, 2026-06-07)
 
 **MUST NEVER:** Call `loadModule` with a relative path. The caller is responsible for joining `workspaceRoot` with the user-provided relative path before passing it in.
 
@@ -56,22 +56,23 @@ const config = raw.default; // undefined if loadModule already unwrapped
 
 ## Pitfalls
 
-| Trap                                                                 | Reality                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "I can register ts-node with a different tsconfig for a second file" | ts-node registration is process-global and sticky. The first tsConfig wins; subsequent calls with a different tsConfig are silently ignored with a warning log. `_tsNodeRegister` (lines 5-43) only registers once. (Source: code investigation, 2026-02-16)                                                                                                                                                                                                                                                  |
-| "Default export unwrapping is simple"                                | `loadModule` does `require(path).default \|\| require(path)` for `.ts` and `.js` files (lines 96, 111). If a module exports `{ default: { default: ... } }`, the outer default is unwrapped, returning the inner `{ default: ... }` object -- not the deeply nested value. Users exporting double-wrapped defaults will get unexpected results. (Source: code investigation, 2026-02-16)                                                                                                                      |
-| "ESM loading uses standard `import()`"                               | TypeScript unconditionally downlevels `import()` to `require()`, which cannot load ESM modules. The code uses `new Function('modulePath', 'return import(modulePath)')` to create the import expression at runtime, preventing TypeScript from transforming it. This is the same pattern used by Angular CLI internally. Can be dropped once TypeScript supports preserving dynamic imports (see JSDoc at `src/load-module.ts` lines 57-71). Do not "simplify" this. (Source: code investigation, 2026-02-16) |
-| "`resolvePackagePath` is just `path.join`"                           | It resolves from the package's actual installed location (via `require.resolve` on `package.json`), not from the workspace root. This matters when packages are hoisted differently.                                                                                                                                                                                                                                                                                                                          |
-| "ESM/CJS interop is straightforward"                                 | ESM/CJS interop has been a significant pain point with multiple abandoned approaches before landing on the current implementation. Do not attempt to "simplify" the loading logic without understanding the full history of failures. (Source: SME interview, Jeb, 2026-02-16)                                                                                                                                                                                                                                |
+| Trap                                                            | Reality                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "I can pin ts-node compiler options / one tsconfig per process" | There is no ts-node anymore. Loading is via jiti with one isolated instance per `tsConfig` (cached by path), so different configs/transforms resolve against their own tsconfig. (Source: code investigation, 2026-06-07)                                                                                                                                                                                        |
+| "Default export unwrapping is simple"                           | `loadModule` returns `mod.default ?? mod` over jiti's `interopDefault` result. A single default export is unwrapped; a nested `{ default: ... }` is preserved (covered by `load-module.spec.ts`). Double-wrapped defaults still yield the inner object, not the deepest value. (Source: code investigation, 2026-06-07)                                                                                          |
+| "jiti's `tsconfigPaths` option honors any tsconfig path"        | It does not -- jiti/`get-tsconfig` treats the path as a search location and only loads a file literally named `tsconfig.json`, walking up otherwise. Build targets use names like `tsconfig.app.json`, so `loadModule` parses the exact `tsConfig` via `get-tsconfig`'s `parseTsconfig` and builds jiti's `alias` map itself. Do not switch to `tsconfigPaths: <path>`. (Source: code investigation, 2026-06-07) |
+| "`resolvePackagePath` is just `path.join`"                      | It resolves from the package's actual installed location (via `require.resolve` on `package.json`), not from the workspace root. This matters when packages are hoisted differently.                                                                                                                                                                                                                             |
+| "ESM/CJS interop is straightforward"                            | ESM/CJS interop has been a significant pain point with multiple abandoned approaches before landing on the current implementation. Do not attempt to "simplify" the loading logic without understanding the full history of failures. (Source: SME interview, Jeb, 2026-02-16)                                                                                                                                   |
 
 ## Testing
 
 ```bash
-# No dedicated unit tests -- tested transitively through consumer packages
+# Loader unit tests (all module formats + #816/#2025 regressions):
+npx jest --config jest-ut.config.js packages/common/src/load-module.spec.ts
 yarn build  # from packages/common
 ```
 
 ## Dependencies
 
 **Breaks if changed:** `custom-esbuild` (plugin loading), `custom-webpack` (config + transform loading), `jest` (listed dependency but indirect usage)
-**Breaks us if changed:** `ts-node`, `tsconfig-paths`, `@angular-devkit/core` (for `logging.LoggerApi` type)
+**Breaks us if changed:** `jiti` (module loading + TS transform), `get-tsconfig` (tsconfig path-alias parsing), `@angular-devkit/core` (for `logging.LoggerApi` type)

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -33,14 +33,14 @@
     "prebuild": "yarn clean",
     "build": "yarn prebuild && tsc && tsc -p tsconfig.schematics.json && yarn copy:schematics",
     "copy:schematics": "copyfiles -u 2 \"src/schematics/**/*.json\" dist/schematics && copyfiles -u 2 \"src/schematics/**/files/**\" dist/schematics",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "test": "jest --config ../../jest-ut.config.js packages/common/src/load-module.spec.ts"
   },
   "dependencies": {
     "@angular-devkit/core": "^22.0.0-rc.2",
     "@angular-devkit/schematics": "^22.0.0-rc.2",
     "@schematics/angular": "^22.0.0-rc.2",
-    "ts-node": "^10.0.0",
-    "tsconfig-paths": "^4.2.0"
+    "jiti": "^2.7.0"
   },
   "devDependencies": {
     "copyfiles": "^2.4.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -40,6 +40,7 @@
     "@angular-devkit/core": "^22.0.0-rc.2",
     "@angular-devkit/schematics": "^22.0.0-rc.2",
     "@schematics/angular": "^22.0.0-rc.2",
+    "get-tsconfig": "^4.10.0",
     "jiti": "^2.7.0"
   },
   "devDependencies": {

--- a/packages/common/src/load-module.fixtures/aliased-alt/value.ts
+++ b/packages/common/src/load-module.fixtures/aliased-alt/value.ts
@@ -1,0 +1,1 @@
+export const value = 'aliased-alt';

--- a/packages/common/src/load-module.fixtures/aliased/value.ts
+++ b/packages/common/src/load-module.fixtures/aliased/value.ts
@@ -1,0 +1,1 @@
+export const value = 'aliased-base';

--- a/packages/common/src/load-module.fixtures/config-alias-alt.ts
+++ b/packages/common/src/load-module.fixtures/config-alias-alt.ts
@@ -1,0 +1,2 @@
+import { value } from '@fixtures/value';
+export default { name: value };

--- a/packages/common/src/load-module.fixtures/config-alias.ts
+++ b/packages/common/src/load-module.fixtures/config-alias.ts
@@ -1,0 +1,2 @@
+import { value } from '@fixtures/value';
+export default { name: value };

--- a/packages/common/src/load-module.fixtures/config-double-default.ts
+++ b/packages/common/src/load-module.fixtures/config-double-default.ts
@@ -1,0 +1,1 @@
+export default { default: { name: 'inner' } };

--- a/packages/common/src/load-module.fixtures/config-json-import.ts
+++ b/packages/common/src/load-module.fixtures/config-json-import.ts
@@ -1,0 +1,2 @@
+import data from './data.json';
+export default { name: data.name };

--- a/packages/common/src/load-module.fixtures/config-tla.mjs
+++ b/packages/common/src/load-module.fixtures/config-tla.mjs
@@ -1,0 +1,2 @@
+const value = await Promise.resolve('tla');
+export default { name: value };

--- a/packages/common/src/load-module.fixtures/config.cjs
+++ b/packages/common/src/load-module.fixtures/config.cjs
@@ -1,0 +1,1 @@
+module.exports = { name: 'cjs' };

--- a/packages/common/src/load-module.fixtures/config.cts
+++ b/packages/common/src/load-module.fixtures/config.cts
@@ -1,0 +1,1 @@
+module.exports = { name: 'cts' };

--- a/packages/common/src/load-module.fixtures/config.js
+++ b/packages/common/src/load-module.fixtures/config.js
@@ -1,0 +1,1 @@
+module.exports = { name: 'js-cjs' };

--- a/packages/common/src/load-module.fixtures/config.mjs
+++ b/packages/common/src/load-module.fixtures/config.mjs
@@ -1,0 +1,1 @@
+export default { name: 'mjs' };

--- a/packages/common/src/load-module.fixtures/config.mts
+++ b/packages/common/src/load-module.fixtures/config.mts
@@ -1,0 +1,1 @@
+export default { name: 'mts' };

--- a/packages/common/src/load-module.fixtures/config.ts
+++ b/packages/common/src/load-module.fixtures/config.ts
@@ -1,0 +1,1 @@
+export default { name: 'ts' };

--- a/packages/common/src/load-module.fixtures/data.json
+++ b/packages/common/src/load-module.fixtures/data.json
@@ -1,0 +1,1 @@
+{ "name": "from-json" }

--- a/packages/common/src/load-module.fixtures/tsconfig.alt.json
+++ b/packages/common/src/load-module.fixtures/tsconfig.alt.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@fixtures/value": ["./aliased-alt/value.ts"]
+    }
+  }
+}

--- a/packages/common/src/load-module.fixtures/tsconfig.json
+++ b/packages/common/src/load-module.fixtures/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@fixtures/value": ["./aliased/value.ts"]
+    }
+  }
+}

--- a/packages/common/src/load-module.spec.ts
+++ b/packages/common/src/load-module.spec.ts
@@ -1,0 +1,70 @@
+import { resolve } from 'node:path';
+import type { logging } from '@angular-devkit/core';
+import { loadModule } from './load-module';
+
+const FIXTURES = resolve(__dirname, 'load-module.fixtures');
+const TSCONFIG = resolve(FIXTURES, 'tsconfig.json');
+const TSCONFIG_ALT = resolve(FIXTURES, 'tsconfig.alt.json');
+
+// Minimal logger stub — loadModule no longer logs, but the signature requires one.
+const logger = {
+  warn: () => undefined,
+  info: () => undefined,
+  error: () => undefined,
+} as unknown as logging.LoggerApi;
+
+const fixture = (file: string) => resolve(FIXTURES, file);
+
+describe('loadModule', () => {
+  it.each([
+    ['config.ts', 'ts'],
+    ['config.mts', 'mts'],
+    ['config.cts', 'cts'],
+    ['config.js', 'js-cjs'],
+    ['config.mjs', 'mjs'],
+    ['config.cjs', 'cjs'],
+  ])('loads %s', async (file, expected) => {
+    const result = await loadModule<{ name: string }>(fixture(file), TSCONFIG, logger);
+    expect(result).toEqual({ name: expected });
+  });
+
+  it('resolves JSON imports inside a TS config (regression: #816)', async () => {
+    const result = await loadModule<{ name: string }>(
+      fixture('config-json-import.ts'),
+      TSCONFIG,
+      logger
+    );
+    expect(result).toEqual({ name: 'from-json' });
+  });
+
+  it('loads an ESM config that uses top-level await', async () => {
+    const result = await loadModule<{ name: string }>(fixture('config-tla.mjs'), TSCONFIG, logger);
+    expect(result).toEqual({ name: 'tla' });
+  });
+
+  it('resolves tsconfig path aliases from the passed tsConfig', async () => {
+    const result = await loadModule<{ name: string }>(fixture('config-alias.ts'), TSCONFIG, logger);
+    expect(result).toEqual({ name: 'aliased-base' });
+  });
+
+  it('does NOT over-unwrap a double default export', async () => {
+    const result = await loadModule<{ default: { name: string } }>(
+      fixture('config-double-default.ts'),
+      TSCONFIG,
+      logger
+    );
+    // The outer default is unwrapped once; the inner { default: ... } is preserved.
+    expect(result).toEqual({ default: { name: 'inner' } });
+  });
+
+  it('uses each tsConfig independently (regression: sticky-tsconfig)', async () => {
+    const base = await loadModule<{ name: string }>(fixture('config-alias.ts'), TSCONFIG, logger);
+    const alt = await loadModule<{ name: string }>(
+      fixture('config-alias-alt.ts'),
+      TSCONFIG_ALT,
+      logger
+    );
+    expect(base).toEqual({ name: 'aliased-base' });
+    expect(alt).toEqual({ name: 'aliased-alt' });
+  });
+});

--- a/packages/common/src/load-module.ts
+++ b/packages/common/src/load-module.ts
@@ -1,153 +1,124 @@
+/// <reference types="node" />
+// The triple-slash reference above explicitly pulls in `@types/node` global typings
+// (`require`, `process`, `__filename`, the `node:` import specifiers). This package's
+// tsconfig does not set a `types` field, and `@types/node` is not auto-discovered for
+// this program; the previous implementation only got node globals transitively via
+// `typeof import('ts-node')`. Removing ts-node removed that side effect, so we declare
+// the dependency on node types directly here.
 import * as path from 'node:path';
-import * as url from 'node:url';
+import { createJiti } from 'jiti';
+import { parseTsconfig } from 'get-tsconfig';
 import type { logging } from '@angular-devkit/core';
 
-const _tsNodeRegister = (() => {
-  let lastTsConfig: string | undefined;
-  return (tsConfig: string, logger: logging.LoggerApi) => {
-    // Check if the function was previously called with the same tsconfig
-    if (lastTsConfig && lastTsConfig !== tsConfig) {
-      logger.warn(`Trying to register ts-node again with a different tsconfig - skipping the registration.
-                   tsconfig 1: ${lastTsConfig}
-                   tsconfig 2: ${tsConfig}`);
-    }
+type Jiti = ReturnType<typeof createJiti>;
 
-    if (lastTsConfig) {
-      return;
-    }
-
-    lastTsConfig = tsConfig;
-
-    loadTsNode().register({
-      project: tsConfig,
-      compilerOptions: {
-        module: 'CommonJS',
-        // We deliberately do NOT override moduleResolution here.
-        // The user's tsconfig moduleResolution setting (node, bundler, node16, etc.) is preserved.
-        // TypeScript allows moduleResolution:bundler with module:CommonJS, so type checking
-        // works correctly for all moduleResolution values — including 'bundler', which supports
-        // subpath package exports (e.g. '@angular/core/primitives/di').
-        // Overriding moduleResolution to 'node' (as was done previously) was the root cause of
-        // issue https://github.com/just-jeb/angular-builders/issues/2025: it prevented TypeScript
-        // from resolving subpath exports, causing TS2307 errors at build time.
-        resolveJsonModule: true,
-        // resolveJsonModule: true is required so that TypeScript webpack configs can import
-        // JSON files (e.g. `import pkg from './package.json'`). Without this, users on
-        // moduleResolution:'node' (the default for Angular projects before v17) get TS2732:
-        // "Cannot find module './foo.json'. Consider using '--resolveJsonModule'".
-        // This flag is safe to always enable: it has no downside and does not conflict
-        // with any other moduleResolution mode (node, node16, bundler, etc.).
-        // Fix for: https://github.com/just-jeb/angular-builders/issues/816
-        types: [
-          'node', // NOTE: `node` is added so user configs can use Node.js globals (process, __dirname, etc.)
-        ],
-      },
-    });
-
-    const tsConfigPaths = loadTsConfigPaths();
-    const result = tsConfigPaths.loadConfig(tsConfig);
-    // The `loadConfig` returns a `ConfigLoaderResult` which must be guarded with
-    // the `resultType` check.
-    if (result.resultType === 'success') {
-      const { absoluteBaseUrl: baseUrl, paths } = result;
-      if (baseUrl && paths) {
-        tsConfigPaths.register({ baseUrl, paths });
-      }
-    }
-  };
-})();
+// Cache one jiti instance per tsconfig. Repeated loads with the same tsconfig
+// reuse the transform cache; different tsconfigs get isolated instances, so there
+// is no process-global "first tsconfig wins" stickiness (the old ts-node limitation).
+const jitiByTsConfig = new Map<string, Jiti>();
 
 /**
- * check for TS node registration
- * @param file: file name or file directory are allowed
- */
-function tsNodeRegister(file: string = '', tsConfig: string, logger: logging.LoggerApi) {
-  if (file?.endsWith('.ts')) {
-    // Register TS compiler lazily
-    _tsNodeRegister(tsConfig, logger);
-  }
-}
-
-/**
- * This uses a dynamic import to load a module which may be ESM.
- * CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript
- * will currently, unconditionally downlevel dynamic import into a require call.
- * require calls cannot load ESM code and will result in a runtime error. To workaround
- * this, a Function constructor is used to prevent TypeScript from changing the dynamic import.
- * Once TypeScript provides support for keeping the dynamic import this workaround can
- * be dropped.
+ * Builds a jiti `alias` map from a tsconfig's `baseUrl` + `paths`, resolving
+ * `extends` so aliases declared in a base config are honored.
  *
- * @param modulePath The path of the module to load.
- * @returns A Promise that resolves to the dynamically imported module.
+ * Why not jiti's built-in `tsconfigPaths: <path>` option? Internally jiti hands the
+ * string to `get-tsconfig`'s `getTsconfig()`, which treats it as a *search location*
+ * and only ever loads a file literally named `tsconfig.json` — it ignores any other
+ * filename (e.g. `tsconfig.app.json`, which Angular build targets routinely use) and
+ * walks up to the nearest `tsconfig.json`. That silently resolves aliases against the
+ * wrong config and breaks per-target isolation. Parsing the exact file we were handed
+ * with `get-tsconfig`'s `parseTsconfig()` (which honors the precise path and resolves
+ * `extends`) and feeding jiti an explicit `alias` map keeps each jiti instance isolated.
+ *
+ * We use `get-tsconfig` rather than `require('typescript')` deliberately: `common` is a
+ * *published* package and does not declare `typescript` as a runtime dependency, so
+ * `require('typescript')` is unreliable under non-hoisted installs (pnpm / Yarn PnP) —
+ * a strict resolver would fail and aliases would silently break. `get-tsconfig` is a
+ * declared, zero-dependency dependency (the same parser jiti uses internally), so it
+ * always resolves. A missing/invalid tsconfig degrades gracefully to an empty map
+ * (jiti still loads the module — only `paths` aliases are unavailable).
  */
-function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
-  return new Function('modulePath', `return import(modulePath);`)(modulePath) as Promise<T>;
+function tsConfigAliases(tsConfig: string): Record<string, string> {
+  let compilerOptions: { baseUrl?: string; paths?: Record<string, string[]> } | undefined;
+  try {
+    compilerOptions = parseTsconfig(tsConfig).compilerOptions;
+  } catch {
+    return {};
+  }
+
+  const { baseUrl, paths } = compilerOptions ?? {};
+  if (!paths) {
+    return {};
+  }
+
+  // `get-tsconfig` returns `baseUrl` (and the `paths` targets) relative to the *directory
+  // of the tsconfig file we passed* — even when they originate from an extended base
+  // config, it rewrites them to be relative to that directory. So resolve baseUrl against
+  // the tsconfig's dir, and each target against baseUrl. If baseUrl is absent, paths
+  // resolve directly against the tsconfig's dir.
+  const tsConfigDir = path.dirname(tsConfig);
+  const base = baseUrl ? path.resolve(tsConfigDir, baseUrl) : tsConfigDir;
+
+  const aliases: Record<string, string> = {};
+  for (const [alias, targets] of Object.entries(paths)) {
+    const target = targets?.[0];
+    if (!target) {
+      continue;
+    }
+    // Strip the trailing `/*` wildcard from both sides so jiti (prefix matching)
+    // maps `@x/*` -> the resolved target directory; non-wildcard aliases map 1:1.
+    const aliasKey = alias.replace(/\/\*$/, '');
+    const targetPath = target.replace(/\/\*$/, '');
+    aliases[aliasKey] = path.resolve(base, targetPath);
+  }
+
+  return aliases;
+}
+
+function getJiti(tsConfig: string): Jiti {
+  let jiti = jitiByTsConfig.get(tsConfig);
+  if (!jiti) {
+    jiti = createJiti(__filename, {
+      // Resolve TypeScript path aliases (baseUrl/paths) from the build target's
+      // tsconfig. Replaces the previous explicit `tsconfig-paths` registration.
+      // We parse the tsconfig ourselves (see `tsConfigAliases`) rather than using
+      // jiti's `tsconfigPaths` option, which mishandles non-`tsconfig.json` filenames.
+      alias: tsConfigAliases(tsConfig),
+      // Merge module.exports + default export into a single value (Proxy-based),
+      // replacing the previous `require(p).default || require(p)` unwrapping.
+      interopDefault: true,
+      // Persist the transform cache to disk between runs for faster reloads.
+      fsCache: true,
+    });
+    jitiByTsConfig.set(tsConfig, jiti);
+  }
+
+  return jiti;
 }
 
 /**
- * Loads CJS and ESM modules based on extension
+ * Loads a user-provided module (webpack/esbuild config, plugin, or index-html
+ * transformer) regardless of format: `.ts`, `.mts`, `.cts`, `.js`, `.mjs`, `.cjs`.
+ *
+ * All CJS/ESM/TS interop is delegated to jiti. TypeScript is transpiled
+ * transpile-only — there is NO build-time type-checking (run `tsc --noEmit`
+ * separately if you want it; see the package README). This replaces the previous
+ * ts-node + tsconfig-paths + hand-rolled dynamic-import implementation.
+ *
+ * @param modulePath Absolute path to the module to load.
+ * @param tsConfig Absolute path to the tsconfig used for path-alias resolution.
+ * @param _logger Angular logger (retained for API compatibility; unused).
  */
 export async function loadModule<T>(
   modulePath: string,
   tsConfig: string,
-  logger: logging.LoggerApi
+  _logger: logging.LoggerApi
 ): Promise<T> {
-  tsNodeRegister(modulePath, tsConfig, logger);
+  const jiti = getJiti(tsConfig);
+  const mod = await jiti.import<T | { default?: T }>(modulePath);
 
-  switch (path.extname(modulePath)) {
-    case '.mjs':
-      // Load the ESM configuration file using the TypeScript dynamic import workaround.
-      // Once TypeScript provides support for keeping the dynamic import this workaround can be
-      // changed to a direct dynamic import.
-      return (await loadEsmModule<{ default: T }>(url.pathToFileURL(modulePath))).default;
-    case '.cjs':
-      return require(modulePath);
-    case '.ts':
-      try {
-        // If it's a TS file then there are 2 cases for exporting an object.
-        // The first one is `export blah`, transpiled into `module.exports = { blah} `.
-        // The second is `export default blah`, transpiled into `{ default: { ... } }`.
-        return require(modulePath).default || require(modulePath);
-      } catch (e: any) {
-        if (e.code === 'ERR_REQUIRE_ESM') {
-          // Load the ESM configuration file using the TypeScript dynamic import workaround.
-          // Once TypeScript provides support for keeping the dynamic import this workaround can be
-          // changed to a direct dynamic import.
-          return (await loadEsmModule<{ default: T }>(url.pathToFileURL(modulePath))).default;
-        }
-        throw e;
-      }
-    //.js
-    default:
-      // The file could be either CommonJS or ESM.
-      // CommonJS is tried first then ESM if loading fails.
-      try {
-        return require(modulePath).default || require(modulePath);
-      } catch (e: any) {
-        if (e.code === 'ERR_REQUIRE_ESM') {
-          // Load the ESM configuration file using the TypeScript dynamic import workaround.
-          // Once TypeScript provides support for keeping the dynamic import this workaround can be
-          // changed to a direct dynamic import.
-          return (await loadEsmModule<{ default: T }>(url.pathToFileURL(modulePath))).default;
-        }
-
-        throw e;
-      }
-  }
-}
-
-/**
- * Loads `ts-node` lazily. Moved to a separate function to declare
- * a return type, more readable than an inline variant.
- */
-function loadTsNode(): typeof import('ts-node') {
-  return require('ts-node');
-}
-
-/**
- * Loads `tsconfig-paths` lazily. Moved to a separate function to declare
- * a return type, more readable than an inline variant.
- */
-function loadTsConfigPaths(): typeof import('tsconfig-paths') {
-  return require('tsconfig-paths');
+  // With interopDefault, `mod` already merges named + default exports. The explicit
+  // `.default` access preserves parity with the previous unwrap for modules that
+  // only set a default export, without over-unwrapping a nested `{ default: ... }`.
+  return ((mod as { default?: T })?.default ?? mod) as T;
 }

--- a/packages/common/src/schematics/index.ts
+++ b/packages/common/src/schematics/index.ts
@@ -1,5 +1,6 @@
 export * from './rules';
 export * from './detection';
 export * from './version';
+export * from './migrate-jiti-loader';
 // testing.ts is exported via the ./schematics/testing subpath, not the barrel,
 // so production schematics never pull SchematicTestRunner into their bundle.

--- a/packages/common/src/schematics/migrate-jiti-loader.spec.ts
+++ b/packages/common/src/schematics/migrate-jiti-loader.spec.ts
@@ -1,0 +1,92 @@
+import * as path from 'path';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { SchematicTestHarness } from './testing';
+import { migrateToJitiLoader } from './migrate-jiti-loader';
+
+const NG = path.join(
+  path.dirname(require.resolve('@schematics/angular/package.json')),
+  'collection.json'
+);
+const runner = () => new SchematicTestRunner('t', NG);
+
+const PKG = '@angular-builders/custom-webpack';
+
+async function seed(
+  mutate: (pkg: Record<string, any>) => void,
+  tsconfig?: Record<string, unknown>
+): Promise<UnitTestTree> {
+  const tree = await new SchematicTestHarness().createWorkspace({ projects: [{ name: 'app' }] });
+  const pkg = JSON.parse(tree.readText('/package.json'));
+  pkg.scripts = pkg.scripts ?? {};
+  pkg.devDependencies = pkg.devDependencies ?? {};
+  mutate(pkg);
+  tree.overwrite('/package.json', JSON.stringify(pkg, null, 2));
+  if (tsconfig) {
+    tree.overwrite('/tsconfig.json', JSON.stringify(tsconfig, null, 2));
+  }
+  return tree;
+}
+
+async function migrate(tree: UnitTestTree): Promise<UnitTestTree> {
+  return (await runner().callRule(migrateToJitiLoader(PKG), tree).toPromise()) as UnitTestTree;
+}
+
+describe('migrateToJitiLoader', () => {
+  it('strips the ts-node/esm NODE_OPTIONS workaround from npm scripts', async () => {
+    const tree = await seed(pkg => {
+      pkg.scripts['build-ts'] =
+        "TS_NODE_PROJECT=tsconfig.app.json NODE_OPTIONS='--loader ts-node/esm' ng build";
+      pkg.scripts['build'] = 'ng build';
+    });
+    const out = await migrate(tree);
+    const pkg = JSON.parse(out.readText('/package.json'));
+    expect(pkg.scripts['build-ts']).toBe('ng build');
+    expect(pkg.scripts['build']).toBe('ng build');
+  });
+
+  it('removes ts-node and tsconfig-paths from devDependencies', async () => {
+    const tree = await seed(pkg => {
+      pkg.devDependencies['ts-node'] = '10.9.2';
+      pkg.devDependencies['tsconfig-paths'] = '4.2.0';
+      pkg.devDependencies['typescript'] = '5.0.0';
+    });
+    const out = await migrate(tree);
+    const pkg = JSON.parse(out.readText('/package.json'));
+    expect(pkg.devDependencies['ts-node']).toBeUndefined();
+    expect(pkg.devDependencies['tsconfig-paths']).toBeUndefined();
+    expect(pkg.devDependencies['typescript']).toBe('5.0.0');
+  });
+
+  it('lifts a path-only `ts-node` tsconfig section into compilerOptions and removes the section', async () => {
+    const tree = await seed(() => undefined, {
+      compilerOptions: { strict: true, paths: { '@app/*': ['./src/app/*'] } },
+      'ts-node': { compilerOptions: { paths: { '@cfg/*': ['./cfg/*'] } } },
+    });
+    const out = await migrate(tree);
+    const cfg = JSON.parse(out.readText('/tsconfig.json'));
+    expect(cfg.compilerOptions.paths['@cfg/*']).toEqual(['./cfg/*']);
+    expect(cfg.compilerOptions.paths['@app/*']).toEqual(['./src/app/*']);
+    expect(cfg['ts-node']).toBeUndefined();
+  });
+
+  it('keeps a `ts-node` section that has non-path overrides (cannot be applied safely)', async () => {
+    const tree = await seed(() => undefined, {
+      compilerOptions: { strict: true },
+      'ts-node': { compilerOptions: { target: 'ES2022' } },
+    });
+    const out = await migrate(tree);
+    const cfg = JSON.parse(out.readText('/tsconfig.json'));
+    expect(cfg['ts-node']).toEqual({ compilerOptions: { target: 'ES2022' } });
+  });
+
+  it('does not add a path alias that already exists in compilerOptions', async () => {
+    const tree = await seed(() => undefined, {
+      compilerOptions: { paths: { '@cfg/*': ['./real/*'] } },
+      'ts-node': { compilerOptions: { paths: { '@cfg/*': ['./override/*'] } } },
+    });
+    const out = await migrate(tree);
+    const cfg = JSON.parse(out.readText('/tsconfig.json'));
+    // The existing mapping wins; the ts-node override does not clobber it.
+    expect(cfg.compilerOptions.paths['@cfg/*']).toEqual(['./real/*']);
+  });
+});

--- a/packages/common/src/schematics/migrate-jiti-loader.ts
+++ b/packages/common/src/schematics/migrate-jiti-loader.ts
@@ -1,0 +1,161 @@
+import { chain, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { JsonValue, workspaces } from '@angular-devkit/core';
+import { readWorkspace } from '@schematics/angular/utility';
+import { JSONFile } from '@schematics/angular/utility/json-file';
+import { removeDevDependencies } from './rules';
+
+/**
+ * Shared `ng update` migration for the move from ts-node to jiti as the loader for
+ * user-provided TypeScript modules (configs, plugins, transformers).
+ *
+ * It performs the changes that are safe to automate and advises on the rest:
+ *  - strips the `NODE_OPTIONS='--loader ts-node/esm'` / `TS_NODE_PROJECT=…` workaround
+ *    from npm scripts (these now fail because ts-node is no longer installed, and are
+ *    unnecessary — jiti loads `.ts` configs in ESM projects directly);
+ *  - removes `ts-node` / `tsconfig-paths` from devDependencies;
+ *  - lifts `paths`/`baseUrl` from a now-ignored `ts-node` tsconfig section into the
+ *    standard `compilerOptions` (jiti reads them from there), skipping colliding keys;
+ *  - advises (without changing files) on anything that cannot be migrated safely:
+ *    non-path overrides in a `ts-node` section, and the loss of build-time type-checking.
+ *
+ * @param packageName The builder package name, used only as a log prefix.
+ */
+export function migrateToJitiLoader(packageName: string): Rule {
+  return async (tree: Tree, context: SchematicContext) => {
+    const workspace = await readWorkspace(tree);
+    const tsconfigPaths = collectTsconfigPaths(workspace);
+
+    return chain([
+      stripTsNodeEsmFromScripts(packageName),
+      removeDevDependencies(['ts-node', 'tsconfig-paths']),
+      migrateTsNodeTsconfigSections(packageName, tsconfigPaths),
+      adviseTypeChecking(packageName),
+    ]);
+  };
+}
+
+function collectTsconfigPaths(workspace: workspaces.WorkspaceDefinition): string[] {
+  const paths = new Set<string>(['/tsconfig.json', '/tsconfig.base.json']);
+  for (const project of workspace.projects.values()) {
+    for (const target of project.targets.values()) {
+      const tsConfig = (target.options as Record<string, unknown> | undefined)?.['tsConfig'];
+      if (typeof tsConfig === 'string') {
+        paths.add('/' + tsConfig.replace(/^\/+/, ''));
+      }
+    }
+  }
+  return [...paths];
+}
+
+function stripTsNodeEsmFromScripts(packageName: string): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    if (!tree.exists('/package.json')) return tree;
+    const json = new JSONFile(tree, '/package.json');
+    const scripts = json.get(['scripts']) as Record<string, JsonValue> | undefined;
+    if (!scripts) return tree;
+
+    let changed = false;
+    for (const [name, value] of Object.entries(scripts)) {
+      if (typeof value !== 'string') continue;
+      const next = value
+        .replace(/\bTS_NODE_PROJECT=\S+\s+/g, '')
+        .replace(
+          /\bNODE_OPTIONS=(?:'--loader ts-node\/esm'|"--loader ts-node\/esm"|--loader[= ]ts-node\/esm)\s+/g,
+          ''
+        )
+        // A `cross-env` that is now left immediately before the `ng` command is redundant.
+        .replace(/^cross-env\s+(?=ng\b)/, '')
+        .trim();
+      if (next !== value) {
+        json.modify(['scripts', name], next);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      context.logger.info(
+        `[${packageName}] Removed the \`ts-node/esm\` NODE_OPTIONS loader workaround from npm ` +
+          `scripts — TypeScript configs now load via jiti with plain \`ng\` commands.`
+      );
+    }
+    return tree;
+  };
+}
+
+function migrateTsNodeTsconfigSections(packageName: string, tsconfigPaths: string[]): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    for (const path of tsconfigPaths) {
+      if (!tree.exists(path)) continue;
+      const json = new JSONFile(tree, path);
+      const section = json.get(['ts-node']) as
+        | { compilerOptions?: Record<string, JsonValue> }
+        | undefined;
+      const tsNodeCompilerOptions = section?.compilerOptions;
+      if (!tsNodeCompilerOptions) continue;
+
+      const { paths, baseUrl, ...rest } = tsNodeCompilerOptions;
+
+      // jiti reads `paths`/`baseUrl` from the standard compilerOptions, so lift them there.
+      if (paths && typeof paths === 'object') {
+        const existing =
+          (json.get(['compilerOptions', 'paths']) as Record<string, JsonValue>) ?? {};
+        const merged = { ...existing };
+        let addedAlias = false;
+        for (const [alias, target] of Object.entries(paths as Record<string, JsonValue>)) {
+          if (!(alias in existing)) {
+            merged[alias] = target;
+            addedAlias = true;
+          }
+        }
+        if (addedAlias) {
+          ensureCompilerOptions(json);
+          json.modify(['compilerOptions', 'paths'], merged);
+        }
+      }
+      if (typeof baseUrl === 'string' && json.get(['compilerOptions', 'baseUrl']) === undefined) {
+        ensureCompilerOptions(json);
+        json.modify(['compilerOptions', 'baseUrl'], baseUrl);
+      }
+
+      const leftover = Object.keys(rest);
+      if (leftover.length > 0) {
+        // Non-path overrides (target, module, lib, …) cannot be lifted into the main
+        // compilerOptions without also changing the app compile, so leave the section
+        // in place and tell the user how to relocate it.
+        context.logger.warn(
+          `[${packageName}] ${path}: the \`ts-node\` section is no longer read by the builder ` +
+            `(loading uses jiti). Its path options were moved to \`compilerOptions\`, but these ` +
+            `overrides were left untouched and now have no effect: ${leftover.join(', ')}. ` +
+            `If your config files need them, move them into a dedicated tsconfig used only for ` +
+            `\`tsc --noEmit\` (see the package README).`
+        );
+      } else {
+        // Fully migrated — drop the now-empty/path-only section.
+        json.remove(['ts-node']);
+        context.logger.info(
+          `[${packageName}] ${path}: migrated the \`ts-node\` section's path options into ` +
+            `\`compilerOptions\` and removed the obsolete section.`
+        );
+      }
+    }
+    return tree;
+  };
+}
+
+function ensureCompilerOptions(json: JSONFile): void {
+  if (json.get(['compilerOptions']) === undefined) {
+    json.modify(['compilerOptions'], {});
+  }
+}
+
+function adviseTypeChecking(packageName: string): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    context.logger.warn(
+      `[${packageName}] TypeScript configs/plugins are now transpiled by jiti and are NO LONGER ` +
+        `type-checked at build time (your editor still type-checks them). To enforce type-checking ` +
+        `in CI, add a dedicated tsconfig that \`include\`s your config files and run ` +
+        `\`tsc --noEmit -p tsconfig.build-config.json\`. See the package README.`
+    );
+    return tree;
+  };
+}

--- a/packages/custom-esbuild/README.md
+++ b/packages/custom-esbuild/README.md
@@ -23,7 +23,6 @@ Allow customizing ESBuild configuration
 
 > ⚠️ **Version alignment:** The major version of `@angular-builders/custom-esbuild` must match the major version of `@angular/core` in your project. For example, Angular 19 requires `@angular-builders/custom-esbuild`@19.x, Angular 20 requires `@angular-builders/custom-esbuild`@20.x, etc. Using a mismatched version is the most common source of issues.
 
-
 ## Previous versions
 
 <details>
@@ -334,5 +333,22 @@ Custom ESBuild builder fully supports ESM.
 
 - If your app has `"type": "module"` both `plugin.js` and `index-html-transformer.js` will be treated as ES modules, unless you change their file extension to `.cjs`. In that case they'll be treated as CommonJS Modules. [Example](../../examples/custom-esbuild/sanity-esbuild-app-esm).
 - For `"type": "commonjs"` (or unspecified type) both `plugin.js` and `index-html-transformer.js` will be treated as CommonJS modules unless you change their file extension to `.mjs`. In that case they'll be treated as ES Modules. [Example](../../examples/custom-esbuild/sanity-esbuild-app).
-- If you want to use TS config in ESM app, you must set the loader to `ts-node/esm` when running `ng build`. Also, in that case `tsconfig.json` for `ts-node` no longer defaults to `tsConfig` from the `application` target - you have to specify it manually via environment variable. [Example](../../examples/custom-esbuild/sanity-esbuild-app-esm/package.json#L9).  
-  _Note that tsconfig paths are not supported in TS configs within ESM apps. That is because [tsconfig-paths](https://github.com/dividab/tsconfig-paths) do not support ESM._
+- **TypeScript plugins and transformers work in both CommonJS and ESM projects with no extra setup** — just point the builder at your `.ts` file. (Earlier versions required forcing a `ts-node/esm` loader through `NODE_OPTIONS`; that is no longer necessary.) TypeScript path aliases are supported in both module formats.
+
+### Type-checking TypeScript plugins and transformers
+
+`.ts` plugins and `indexHtmlTransformer` files are loaded with [jiti](https://github.com/unjs/jiti) and **transpiled, not type-checked**, at build time. Your editor still type-checks them as you write. To enforce type-checking in CI, add a dedicated tsconfig that includes them and run `tsc`:
+
+`tsconfig.build-config.json`:
+
+```jsonc
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": true },
+  "include": ["plugins/**/*.ts", "index-html-transformer.ts"],
+}
+```
+
+```bash
+tsc --noEmit -p tsconfig.build-config.json
+```

--- a/packages/custom-esbuild/package.json
+++ b/packages/custom-esbuild/package.json
@@ -43,6 +43,9 @@
   "ng-add": {
     "save": "devDependencies"
   },
+  "ng-update": {
+    "migrations": "./dist/schematics/migrations.json"
+  },
   "dependencies": {
     "@angular-builders/common": "workspace:*",
     "@angular-devkit/architect": ">=0.2200.0-rc.2 < 0.2300.0",

--- a/packages/custom-esbuild/package.json
+++ b/packages/custom-esbuild/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "prebuild": "yarn clean",
-    "build": "yarn prebuild && tsc && ts-node ../../merge-schemes.ts && tsc -p tsconfig.schematics.json && yarn copy:schematics && yarn postbuild",
+    "build": "yarn prebuild && tsc && jiti ../../merge-schemes.ts && tsc -p tsconfig.schematics.json && yarn copy:schematics && yarn postbuild",
     "copy:schematics": "copyfiles -u 2 \"src/schematics/**/*.json\" dist/schematics",
     "postbuild": "yarn test && yarn run e2e",
     "test": "jest --config ../../jest-ut.config.js",
@@ -61,7 +61,6 @@
     "esbuild": "0.28.0",
     "jest": "30.4.2",
     "rimraf": "^6.0.0",
-    "ts-node": "^10.0.0",
     "typescript": "6.0.3"
   }
 }

--- a/packages/custom-esbuild/src/load-index-html-transformer.spec.ts
+++ b/packages/custom-esbuild/src/load-index-html-transformer.spec.ts
@@ -1,15 +1,22 @@
 import { loadIndexHtmlTransformer } from './load-index-html-transformer';
 import { Target } from '@angular-devkit/architect';
+import { loadModule } from '@angular-builders/common';
+
+// Module loading is the responsibility of `@angular-builders/common` (covered by
+// its own load-module.spec). Here we mock `loadModule` so this test exercises
+// loadIndexHtmlTransformer's own wiring (passing the target to the transformer).
+jest.mock('@angular-builders/common', () => ({ loadModule: jest.fn() }));
+
+const mockedLoadModule = loadModule as jest.MockedFunction<typeof loadModule>;
 
 describe('loadIndexHtmlTransformer', () => {
   beforeEach(() => {
-    jest.resetModules();
     jest.clearAllMocks();
   });
 
   it('should pass the target to the transformer', async () => {
     const transformIndexHtml = jest.fn();
-    jest.mock('test/test-index-transform.js', () => transformIndexHtml, { virtual: true });
+    mockedLoadModule.mockResolvedValue(transformIndexHtml as never);
     const mockTarget = { project: 'test', target: 'test' } as Target;
     const transform = await loadIndexHtmlTransformer(
       'test/test-index-transform.js',

--- a/packages/custom-esbuild/src/load-plugin.spec.ts
+++ b/packages/custom-esbuild/src/load-plugin.spec.ts
@@ -1,17 +1,24 @@
 import { loadPlugins } from './load-plugins';
 import { Target } from '@angular-devkit/architect';
 import { Plugin } from 'esbuild';
+import { loadModule } from '@angular-builders/common';
 import { CustomEsbuildApplicationSchema } from './custom-esbuild-schema';
+
+// Module loading is the responsibility of `@angular-builders/common` (covered by
+// its own load-module.spec). Here we mock `loadModule` so these tests exercise
+// loadPlugins' own logic (factory invocation, argument passing, flattening).
+jest.mock('@angular-builders/common', () => ({ loadModule: jest.fn() }));
+
+const mockedLoadModule = loadModule as jest.MockedFunction<typeof loadModule>;
 
 describe('loadPlugin', () => {
   beforeEach(() => {
-    jest.resetModules();
     jest.clearAllMocks();
   });
 
   it('should load a plugin without configuration', async () => {
     const mockPlugin = { name: 'mock' } as Plugin;
-    jest.mock('test/test-plugin.js', () => mockPlugin, { virtual: true });
+    mockedLoadModule.mockResolvedValue(mockPlugin as never);
     const plugin = await loadPlugins(
       ['test-plugin.js'],
       './test',
@@ -29,7 +36,7 @@ describe('loadPlugin', () => {
     const pluginFactory = jest.fn().mockReturnValue(mockPlugin);
     const mockOptions = { tsConfig: './tsconfig.json' } as CustomEsbuildApplicationSchema;
     const mockTarget = { target: 'test' } as Target;
-    jest.mock('test/test-plugin.js', () => pluginFactory, { virtual: true });
+    mockedLoadModule.mockResolvedValue(pluginFactory as never);
     const plugin = await loadPlugins(
       ['test-plugin.js'],
       './test',
@@ -47,7 +54,7 @@ describe('loadPlugin', () => {
     const pluginFactory = jest.fn();
     const mockOptions = { tsConfig: './tsconfig.json' } as CustomEsbuildApplicationSchema;
     const mockTarget = { target: 'test' } as Target;
-    jest.mock('test/test-plugin.js', () => pluginFactory, { virtual: true });
+    mockedLoadModule.mockResolvedValue(pluginFactory as never);
     const plugin = await loadPlugins(
       [{ path: 'test-plugin.js', options: { test: 'test' } }],
       './test',

--- a/packages/custom-esbuild/src/schematics/migrations.json
+++ b/packages/custom-esbuild/src/schematics/migrations.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "migration-v22": {
+      "version": "22.0.0",
+      "description": "Migrate from ts-node to the jiti loader: strip the ts-node/esm NODE_OPTIONS workaround from npm scripts, remove ts-node/tsconfig-paths devDependencies, lift `ts-node` tsconfig path options into compilerOptions, and advise on the build-time type-checking change.",
+      "factory": "./migrations/v22/index#migrateV22"
+    }
+  }
+}

--- a/packages/custom-esbuild/src/schematics/migrations/v22/index.spec.ts
+++ b/packages/custom-esbuild/src/schematics/migrations/v22/index.spec.ts
@@ -1,0 +1,25 @@
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { SchematicTestHarness } from '@angular-builders/common/schematics/testing';
+
+// Run the migration through the REAL migrations.json collection so the `ng-update`
+// wiring (factory path, schematic name) is exercised — not just the shared rule.
+const COLLECTION = require.resolve('../../../../src/schematics/migrations.json');
+
+describe('custom-esbuild migration-v22 (jiti loader) wiring', () => {
+  it('runs via the collection and applies the jiti loader migration', async () => {
+    const runner = new SchematicTestRunner('custom-esbuild-migrations', COLLECTION);
+    const tree = await new SchematicTestHarness().createWorkspace({ projects: [{ name: 'app' }] });
+    const pkg = JSON.parse(tree.readText('/package.json'));
+    pkg.scripts = {
+      ...(pkg.scripts ?? {}),
+      'build-ts': "NODE_OPTIONS='--loader ts-node/esm' ng build",
+    };
+    pkg.devDependencies = { ...(pkg.devDependencies ?? {}), 'ts-node': '10.9.2' };
+    tree.overwrite('/package.json', JSON.stringify(pkg, null, 2));
+
+    const out = (await runner.runSchematic('migration-v22', {}, tree)) as UnitTestTree;
+    const result = JSON.parse(out.readText('/package.json'));
+    expect(result.scripts['build-ts']).toBe('ng build');
+    expect(result.devDependencies['ts-node']).toBeUndefined();
+  });
+});

--- a/packages/custom-esbuild/src/schematics/migrations/v22/index.ts
+++ b/packages/custom-esbuild/src/schematics/migrations/v22/index.ts
@@ -1,0 +1,10 @@
+import { Rule } from '@angular-devkit/schematics';
+import { migrateToJitiLoader } from '@angular-builders/common/schematics';
+
+/**
+ * v22: the builder now loads TypeScript esbuild plugins and index transformers via jiti
+ * instead of ts-node. Delegates to the shared migration in `@angular-builders/common`.
+ */
+export function migrateV22(): Rule {
+  return migrateToJitiLoader('@angular-builders/custom-esbuild');
+}

--- a/packages/custom-esbuild/tests/integration.js
+++ b/packages/custom-esbuild/tests/integration.js
@@ -13,7 +13,8 @@ module.exports = [
   {
     id: 'ng-add-esbuild-webpack-guard',
     name: 'custom-esbuild: ng add webpack guard',
-    purpose: 'ng add leaves a webpack build untouched and emits the use-application-builder advisory',
+    purpose:
+      'ng add leaves a webpack build untouched and emits the use-application-builder advisory',
     app: '.',
     command:
       'node scripts/e2e-ng-add.js --spec packages/custom-esbuild/tests/e2e/webpack-guard.ng-add.json',
@@ -53,7 +54,7 @@ module.exports = [
     name: 'custom-esbuild: Vitest TS config',
     purpose: 'Unit test builder loads TypeScript config',
     app: 'examples/custom-esbuild/sanity-esbuild-app-esm',
-    command: 'yarn test-ts -c tsEsm --no-watch',
+    command: 'yarn test -c tsEsm --no-watch',
   },
 
   // Application builder + plugins tests
@@ -106,15 +107,14 @@ module.exports = [
     name: 'custom-esbuild: TS plugins ESM imports',
     purpose: 'Builder loads TypeScript plugins with ESM imports',
     app: 'examples/custom-esbuild/sanity-esbuild-app-esm',
-    command: 'yarn build-ts -c tsEsm',
+    command: 'yarn build -c tsEsm',
   },
 
   // Target options accessibility (#1690, #1710)
   {
     id: 'target-options-in-plugin-and-transformer',
     name: 'custom-esbuild: target.configuration accessible in plugin and indexHtmlTransformer',
-    purpose:
-      'Factory plugin and indexHtmlTransformer both receive target.configuration at runtime',
+    purpose: 'Factory plugin and indexHtmlTransformer both receive target.configuration at runtime',
     app: 'examples/custom-esbuild/sanity-esbuild-app',
     command: 'yarn build-target-options',
   },

--- a/packages/custom-webpack/README.md
+++ b/packages/custom-webpack/README.md
@@ -583,37 +583,25 @@ In the example we add a paragraph with build configuration to your `index.html`.
 
 Full example [here](../../examples/custom-webpack/full-cycle-app).
 
-### Using a Custom TypeScript Configuration for indexTransform
+### Type-checking TypeScript configs and transforms
 
-If your `indexTransform` file requires different TypeScript settings than the build target's `tsConfig` (different `target`, custom `paths`, additional `lib` entries, etc.), you can specify them via the `ts-node` section of your `tsconfig.json`. The builder picks up these options when registering ts-node for transform/config loading.
+`customWebpackConfig` and `indexTransform` files written in TypeScript are loaded with [jiti](https://github.com/unjs/jiti) and **transpiled, not type-checked**, at build time. Your editor still type-checks them as you write, and TypeScript path aliases (`baseUrl`/`paths`) declared in the build target's `tsConfig` are honored.
 
-For example, to make `target` and `paths` available specifically when ts-node loads your transform:
+To enforce type-checking of these files in CI, add a dedicated tsconfig that includes them and run `tsc`:
 
-`tsconfig.json`:
+`tsconfig.build-config.json`:
 
-```json
+```jsonc
 {
-  "compilerOptions": {
-    ...
-  },
-  "ts-node": {
-    "compilerOptions": {
-      "target": "ES2022",
-      "paths": {
-        "@shared/*": ["./shared/*"]
-      }
-    }
-  }
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": true },
+  "include": ["webpack.config.ts", "index-html-transform.ts"],
 }
 ```
 
-> **Note:** ts-node is registered once per builder run; the first tsconfig encountered governs subsequent loads in the same process. If you have both an `indexTransform.ts` and a `webpack.config.ts`, both will resolve against the same ts-node configuration.
-
-> Some options the builder explicitly overrides (notably `module: "commonjs"`) cannot be changed through this mechanism. Use it for options the builder doesn't hard-code.
-
-For more details on `ts-node` configuration options, see the [ts-node documentation](https://typestrong.org/ts-node/docs/configuration/#via-tsconfigjson-recommended).
-
-The same approach applies to `customWebpackConfig` if it's written in TypeScript.
+```bash
+tsc --noEmit -p tsconfig.build-config.json
+```
 
 # ES Modules (ESM) Support
 
@@ -621,8 +609,7 @@ Custom Webpack builder fully supports ESM.
 
 - If your app has `"type": "module"` both `custom-webpack.js` and `index-transform.js` will be treated as ES modules, unless you change their file extension to `.cjs`. In that case they'll be treated as CommonJS Modules. [Example](../../examples/custom-webpack/sanity-app-esm).
 - For `"type": "commonjs"` (or unspecified type) both `custom-webpack.js` and `index-transform.js` will be treated as CommonJS modules unless you change their file extension to `.mjs`. In that case they'll be treated as ES Modules. [Example](../../examples/custom-webpack/sanity-app).
-- If you want to use TS config in ESM app, you must set the loader to `ts-node/esm` when running `ng build`. Also, in that case `tsconfig.json` for `ts-node` no longer defaults to `tsConfig` from the `browser` target - you have to specify it manually via environment variable. [Example](../../examples/custom-webpack/sanity-app-esm/package.json#L10).  
-  _Note that tsconfig paths are not supported in TS configs within ESM apps. That is because [tsconfig-paths](https://github.com/dividab/tsconfig-paths) do not support ESM._
+- **TypeScript configs and transforms work in both CommonJS and ESM projects with no extra setup** — just point the builder at your `.ts` file. (Earlier versions required forcing a `ts-node/esm` loader through `NODE_OPTIONS`; that is no longer necessary.) TypeScript path aliases are supported in both module formats.
 
 # Verbose Logging
 

--- a/packages/custom-webpack/package.json
+++ b/packages/custom-webpack/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "prebuild": "yarn clean",
-    "build": "yarn prebuild && tsc && tsc -p tsconfig.schematics.json && yarn copy:schematics && ts-node ../../merge-schemes.ts && yarn postbuild",
+    "build": "yarn prebuild && tsc && tsc -p tsconfig.schematics.json && yarn copy:schematics && jiti ../../merge-schemes.ts && yarn postbuild",
     "copy:schematics": "copyfiles -u 2 \"src/schematics/**/*.json\" dist/schematics && copyfiles -u 2 \"src/schematics/**/files/**\" dist/schematics",
     "postbuild": "yarn test && yarn run e2e",
     "test": "jest --config ../../jest-ut.config.js",
@@ -62,7 +62,6 @@
     "copyfiles": "^2.4.1",
     "jest": "30.4.2",
     "rimraf": "^6.0.0",
-    "ts-node": "^10.0.0",
     "typescript": "6.0.3"
   }
 }

--- a/packages/custom-webpack/package.json
+++ b/packages/custom-webpack/package.json
@@ -43,6 +43,9 @@
   "ng-add": {
     "save": "devDependencies"
   },
+  "ng-update": {
+    "migrations": "./dist/schematics/migrations.json"
+  },
   "dependencies": {
     "@angular-builders/common": "workspace:*",
     "@angular-devkit/architect": ">=0.2200.0-rc.2 < 0.2300.0",

--- a/packages/custom-webpack/src/custom-webpack-builder.spec.ts
+++ b/packages/custom-webpack/src/custom-webpack-builder.spec.ts
@@ -2,10 +2,19 @@ import { logging, Path } from '@angular-devkit/core';
 import { Configuration } from 'webpack';
 import { CustomizeRule } from 'webpack-merge';
 
+import { loadModule } from '@angular-builders/common';
+
 import { CustomWebpackBuilder, defaultWebpackConfigPath } from './custom-webpack-builder';
 import { MergeRules } from './custom-webpack-builder-config';
 import * as webpackConfigMerger from './webpack-config-merger';
 import { TargetOptions } from './type-definition';
+
+// Module loading is the responsibility of `@angular-builders/common` (covered by
+// its own load-module.spec). We mock `loadModule` so these tests exercise the
+// builder's own logic (factory vs object vs promise handling, merge, verbose logging).
+jest.mock('@angular-builders/common', () => ({ loadModule: jest.fn() }));
+
+const mockedLoadModule = loadModule as jest.MockedFunction<typeof loadModule>;
 
 const baseWebpackConfig = {
   entry: './main.ts',
@@ -54,8 +63,10 @@ const customWebpackFunctionObj = {
 
 const tsConfig = './tsconfig.app.json';
 
-function createConfigFile<T>(fileName: string, content: T) {
-  jest.mock(`${__dirname}/${fileName}`, () => content, { virtual: true });
+function createConfigFile<T>(_fileName: string, content: T) {
+  // The builder loads the user webpack config through `loadModule`; returning the
+  // content from the mock stands in for the file at `_fileName`.
+  mockedLoadModule.mockResolvedValue(content as never);
 }
 
 describe('CustomWebpackBuilder', () => {

--- a/packages/custom-webpack/src/schematics/migrations.json
+++ b/packages/custom-webpack/src/schematics/migrations.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "migration-v22": {
+      "version": "22.0.0",
+      "description": "Migrate from ts-node to the jiti loader: strip the ts-node/esm NODE_OPTIONS workaround from npm scripts, remove ts-node/tsconfig-paths devDependencies, lift `ts-node` tsconfig path options into compilerOptions, and advise on the build-time type-checking change.",
+      "factory": "./migrations/v22/index#migrateV22"
+    }
+  }
+}

--- a/packages/custom-webpack/src/schematics/migrations/v22/index.spec.ts
+++ b/packages/custom-webpack/src/schematics/migrations/v22/index.spec.ts
@@ -1,0 +1,25 @@
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { SchematicTestHarness } from '@angular-builders/common/schematics/testing';
+
+// Run the migration through the REAL migrations.json collection so the `ng-update`
+// wiring (factory path, schematic name) is exercised — not just the shared rule.
+const COLLECTION = require.resolve('../../../../src/schematics/migrations.json');
+
+describe('custom-webpack migration-v22 (jiti loader) wiring', () => {
+  it('runs via the collection and applies the jiti loader migration', async () => {
+    const runner = new SchematicTestRunner('custom-webpack-migrations', COLLECTION);
+    const tree = await new SchematicTestHarness().createWorkspace({ projects: [{ name: 'app' }] });
+    const pkg = JSON.parse(tree.readText('/package.json'));
+    pkg.scripts = {
+      ...(pkg.scripts ?? {}),
+      'build-ts': "NODE_OPTIONS='--loader ts-node/esm' ng build",
+    };
+    pkg.devDependencies = { ...(pkg.devDependencies ?? {}), 'ts-node': '10.9.2' };
+    tree.overwrite('/package.json', JSON.stringify(pkg, null, 2));
+
+    const out = (await runner.runSchematic('migration-v22', {}, tree)) as UnitTestTree;
+    const result = JSON.parse(out.readText('/package.json'));
+    expect(result.scripts['build-ts']).toBe('ng build');
+    expect(result.devDependencies['ts-node']).toBeUndefined();
+  });
+});

--- a/packages/custom-webpack/src/schematics/migrations/v22/index.ts
+++ b/packages/custom-webpack/src/schematics/migrations/v22/index.ts
@@ -1,0 +1,10 @@
+import { Rule } from '@angular-devkit/schematics';
+import { migrateToJitiLoader } from '@angular-builders/common/schematics';
+
+/**
+ * v22: the builder now loads TypeScript webpack configs and index transforms via jiti
+ * instead of ts-node. Delegates to the shared migration in `@angular-builders/common`.
+ */
+export function migrateV22(): Rule {
+  return migrateToJitiLoader('@angular-builders/custom-webpack');
+}

--- a/packages/custom-webpack/src/transform-factories.spec.ts
+++ b/packages/custom-webpack/src/transform-factories.spec.ts
@@ -1,51 +1,48 @@
-jest.mock('ts-node', () => ({
-  register: jest.fn(),
-}));
-jest.mock('tsconfig-paths', () => ({
-  loadConfig: jest.fn().mockReturnValue({}),
-}));
-import { getTransforms } from './transform-factories';
+import { Target } from '@angular-devkit/architect';
+import { loadModule } from '@angular-builders/common';
+import { getTransforms, indexHtmlTransformFactory } from './transform-factories';
 
-const logger = { warn: jest.fn(msg => console.log(msg)) };
+// Module loading is the responsibility of `@angular-builders/common` (covered by
+// its own load-module.spec). The previous ts-node "register once / warn on a
+// different tsconfig" behavior no longer exists: jiti uses an isolated instance
+// per tsconfig, so there is no process-global registration to assert. These tests
+// verify transform-factories' own wiring instead.
+jest.mock('@angular-builders/common', () => ({ loadModule: jest.fn() }));
 
-describe('getTransforms', () => {
+const mockedLoadModule = loadModule as jest.MockedFunction<typeof loadModule>;
+const logger = { warn: jest.fn(), info: jest.fn() } as any;
+
+describe('transform factories', () => {
   beforeEach(() => {
-    jest.resetModules();
     jest.clearAllMocks();
   });
 
-  it('should call ts-node register once with typescript index-html-transform & custom-webpack-config AND warn if called with a different config', () => {
-    jest.mock('test/index-transform.test.ts', () => jest.fn(), { virtual: true });
-    jest.mock('test/webpack.test.config.ts', () => jest.fn(), { virtual: true });
-    const tsNode = require('ts-node') as jest.Mocked<typeof import('ts-node')>;
-
-    const transforms = getTransforms(
-      {
-        customWebpackConfig: {
-          path: 'webpack.test.config.ts',
-        },
-        indexTransform: 'index-transform.test.ts',
-        tsConfig: 'tsconfig.test.json',
-      },
-      { workspaceRoot: './test', logger } as any
+  it('produces a null indexHtml transform when no indexTransform is configured', () => {
+    const { indexHtml } = getTransforms(
+      { customWebpackConfig: { path: 'webpack.config.ts' }, tsConfig: 'tsconfig.json' } as any,
+      { workspaceRoot: '/root', target: {} as Target, logger } as any
     );
-    transforms.webpackConfiguration({});
 
-    expect(tsNode.register).toHaveBeenCalledTimes(1);
-    expect(logger.warn).not.toHaveBeenCalled();
+    expect(indexHtml).toBeNull();
+  });
 
-    const transforms2 = getTransforms(
-      {
-        customWebpackConfig: {
-          path: 'webpack.test.config.ts',
-        },
-        indexTransform: '',
-        tsConfig: 'tsconfig.test2.json',
-      },
-      { workspaceRoot: './test', logger } as any
+  it('loads the index transform via loadModule and passes the target', async () => {
+    const transformer = jest.fn().mockResolvedValue('<html>transformed</html>');
+    mockedLoadModule.mockResolvedValue(transformer as never);
+    const target = { project: 'app', target: 'build' } as Target;
+
+    const indexHtml = indexHtmlTransformFactory(
+      { indexTransform: 'index.transform.ts', tsConfig: 'tsconfig.json' } as any,
+      { workspaceRoot: '/root', target, logger } as any
     );
-    transforms2.webpackConfiguration({});
 
-    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const result = await indexHtml!('<html></html>');
+
+    expect(mockedLoadModule).toHaveBeenCalledTimes(1);
+    const [transformPath, tsConfigPath] = mockedLoadModule.mock.calls[0];
+    expect(transformPath).toContain('index.transform.ts');
+    expect(tsConfigPath).toContain('tsconfig.json');
+    expect(transformer).toHaveBeenCalledWith(target, '<html></html>');
+    expect(result).toBe('<html>transformed</html>');
   });
 });

--- a/packages/custom-webpack/tests/integration.js
+++ b/packages/custom-webpack/tests/integration.js
@@ -123,7 +123,7 @@ module.exports = [
     name: 'custom-webpack: TS config ESM imports',
     purpose: 'Builder loads TypeScript config with ESM imports',
     app: 'examples/custom-webpack/sanity-app-esm',
-    command: 'yarn build-ts -c tsEsm',
+    command: 'yarn build -c tsEsm',
   },
   {
     id: 'ts-config-bundler-module-resolution',

--- a/packages/custom-webpack/tests/integration.js
+++ b/packages/custom-webpack/tests/integration.js
@@ -9,6 +9,16 @@ module.exports = [
       'node scripts/e2e-ng-add.js --spec packages/custom-webpack/tests/e2e/webpack-add.ng-add.json',
   },
 
+  // --- ng update e2e: ts-node -> jiti loader migration (real CLI) + post-migration build ---
+  {
+    id: 'ng-update-loader-migration-smoke',
+    name: 'custom-webpack: jiti loader migration post-build smoke',
+    purpose:
+      'v22 ng update strips the NODE_OPTIONS ts-node/esm workaround, lifts a ts-node tsconfig section, and removes ts-node deps; ng build is green with a .ts webpack config loaded via jiti',
+    app: '.',
+    command: 'node scripts/e2e-loader-migration.js',
+  },
+
   // Karma builder tests
   {
     id: 'karma-builder-sanity-app',

--- a/packages/jest/src/custom-config.resolver.spec.ts
+++ b/packages/jest/src/custom-config.resolver.spec.ts
@@ -1,12 +1,21 @@
 // Should be defined before any import due to the hoisting
 const existsSyncMock = jest.fn();
 
-import { getSystemPath, normalize } from '@angular-devkit/core';
+import { normalize } from '@angular-devkit/core';
 // TODO: find a way to mock 'fs' only for custom-config.resolver
 jest.mock('fs', () => ({ existsSync: existsSyncMock }));
 
+import { loadModule } from '@angular-builders/common';
+
 import { CustomConfigResolver } from './custom-config.resolver';
 
+// `jest.config.{js,ts}` files are loaded through `@angular-builders/common`'s
+// `loadModule` (covered by its own load-module.spec). Mock it here so these tests
+// exercise the resolver's own logic. `package.json` configs use `require` directly
+// and are still mocked via the virtual module registry below.
+jest.mock('@angular-builders/common', () => ({ loadModule: jest.fn() }));
+
+const mockedLoadModule = loadModule as jest.MockedFunction<typeof loadModule>;
 const jestConfig = { blah: true };
 const mockLogger = <any>{ warn: jest.fn() };
 const customConfigResolver = new CustomConfigResolver({}, mockLogger);
@@ -24,7 +33,7 @@ describe('Resolve global custom config', () => {
 
   it('Should return jest configuration from workspace jest.config.js if exists and no configuration provided in package.json', async () => {
     jest.mock('package.json', () => ({}), { virtual: true });
-    jest.mock('jest.config.js', () => jestConfig, { virtual: true });
+    mockedLoadModule.mockResolvedValue(jestConfig as never);
     existsSyncMock.mockReturnValue(true);
     const customConfig = await customConfigResolver.resolveGlobal(normalize('./'));
     expect(customConfig).toEqual(jestConfig);
@@ -45,9 +54,7 @@ describe('Resolve project custom config', () => {
   });
 
   it('Should return jest configuration from project jest.config.js if exists', async () => {
-    jest.mock(getSystemPath(normalize('./myproject/project-jest.config.js')), () => jestConfig, {
-      virtual: true,
-    });
+    mockedLoadModule.mockResolvedValue(jestConfig as never);
     existsSyncMock.mockReturnValue(true);
     const customConfig = await customConfigResolver.resolveForProject(
       normalize('./myproject'),

--- a/packages/jest/src/schematics/migrations/v22/index.ts
+++ b/packages/jest/src/schematics/migrations/v22/index.ts
@@ -8,11 +8,18 @@ export function migrateV22(): Rule {
         '`const enum` used across files and type-only re-exports without the `type` modifier ' +
         'will now error. Fix the call sites, or restore `isolatedModules: false` in your jest ' +
         'config. We do not change this automatically — the new default is intentional. ' +
-        'See MIGRATION.MD (v21→v22) and #2191.',
+        'See MIGRATION.MD (v21→v22) and #2191.'
+    );
+
+    context.logger.warn(
+      '[@angular-builders/jest] v22: a TypeScript jest config (e.g. `jest.config.ts`) is now ' +
+        'loaded via jiti instead of ts-node. `ts-node` is no longer required just to read the ' +
+        'config, and the config is no longer type-checked when loaded. No action needed unless ' +
+        'you relied on that load-time type check.'
     );
 
     const constEnumHits: string[] = [];
-    tree.visit((path) => {
+    tree.visit(path => {
       if (!path.endsWith('.ts')) return;
       if (path.includes('/node_modules/') || path.includes('/dist/')) return;
       const content = tree.readText(path);
@@ -22,7 +29,7 @@ export function migrateV22(): Rule {
       context.logger.warn(
         '[@angular-builders/jest] Found `const enum` in: ' +
           constEnumHits.join(', ') +
-          ' — these may break under isolatedModules. Convert to a regular `enum` or `as const`.',
+          ' — these may break under isolatedModules. Convert to a regular `enum` or `as const`.'
       );
     }
 
@@ -35,7 +42,7 @@ export function migrateV22(): Rule {
         '[@angular-builders/jest] v22: per-project coverage output now writes to ' +
           '<projectRoot>/coverage instead of ./coverage for projects: ' +
           affected.join(', ') +
-          '. Update any CI/tooling that reads a hardcoded `./coverage/` path. See #2212.',
+          '. Update any CI/tooling that reads a hardcoded `./coverage/` path. See #2212.'
       );
     }
 

--- a/scripts/e2e-loader-migration.js
+++ b/scripts/e2e-loader-migration.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+'use strict';
+// jiti loader migration POST-MIGRATION BUILD SMOKE (custom-webpack).
+//
+// Validates the v22 ts-node -> jiti `ng update` migration end-to-end via the REAL CLI
+// (so the migrations.json wiring + ng-update field are exercised, not just the rule):
+//   1. Generate a fresh v22 app inline (ng new), symlink the workspace node_modules.
+//   2. Point the build target at @angular-builders/custom-webpack:browser with a
+//      TypeScript custom webpack config, and SEED the pre-jiti shape the migration fixes:
+//        - a `build-ts` npm script using NODE_OPTIONS='--loader ts-node/esm' (now broken)
+//        - ts-node / tsconfig-paths in devDependencies
+//        - a `ts-node` section in tsconfig.json with a `paths` override
+//   3. Run ONLY the migration via the real CLI:
+//        ng update @angular-builders/custom-webpack --migrate-only --from=21.0.0 --to=22.0.0 ...
+//   4. Assert the migration transformed the workspace (script stripped, deps removed,
+//      ts-node section's paths lifted into compilerOptions + section dropped).
+//   5. ng build to prove the migrated workspace still builds and the `.ts` webpack config
+//      loads via jiti.
+//
+// Package manager is neutralised during the CLI step via a PATH shim so ng update's install
+// task can't write through the symlinked node_modules (same approach as e2e-jest-migration.js).
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const NG_BIN = path.join(REPO_ROOT, 'node_modules', '.bin', 'ng');
+const APP = 'loader-mig-app';
+
+function run(cmd, args, opts) {
+  console.log(`[loader-migration] $ ${cmd} ${args.join(' ')}  (cwd=${opts.cwd})`);
+  return spawnSync(cmd, args, { stdio: 'inherit', ...opts }).status;
+}
+
+function makePackageManagerShim() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-noop-'));
+  for (const pm of ['npm', 'yarn', 'pnpm', 'cnpm']) {
+    fs.writeFileSync(path.join(dir, pm), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  }
+  return dir;
+}
+
+function seedPreJitiShape(workdir) {
+  // Build target -> custom-webpack:browser with a TypeScript custom webpack config.
+  const ngPath = path.join(workdir, 'angular.json');
+  const ng = JSON.parse(fs.readFileSync(ngPath, 'utf8'));
+  const arch = ng.projects[APP].architect || ng.projects[APP].targets;
+  arch.build = {
+    builder: '@angular-builders/custom-webpack:browser',
+    options: {
+      customWebpackConfig: { path: 'webpack.config.ts' },
+      outputPath: 'dist/' + APP,
+      index: 'src/index.html',
+      main: 'src/main.ts',
+      tsConfig: 'tsconfig.app.json',
+      polyfills: [],
+      assets: [],
+      styles: ['src/styles.scss'],
+    },
+  };
+  fs.writeFileSync(ngPath, JSON.stringify(ng, null, 2));
+
+  // A no-op TypeScript custom webpack config (must be loaded by jiti post-migration).
+  fs.writeFileSync(
+    path.join(workdir, 'webpack.config.ts'),
+    "import { Configuration } from 'webpack';\nexport default (config: Configuration): Configuration => config;\n"
+  );
+
+  // package.json: a broken ts-node/esm script + ts-node/tsconfig-paths devDeps.
+  const pkgPath = path.join(workdir, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  pkg.scripts = pkg.scripts || {};
+  pkg.scripts['build-ts'] = "NODE_OPTIONS='--loader ts-node/esm' ng build";
+  pkg.devDependencies = pkg.devDependencies || {};
+  pkg.devDependencies['ts-node'] = '10.9.2';
+  pkg.devDependencies['tsconfig-paths'] = '4.2.0';
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+  // tsconfig.json: a `ts-node` section with a path override the migration must lift.
+  const tsPath = path.join(workdir, 'tsconfig.json');
+  const ts = JSON.parse(stripJsonComments(fs.readFileSync(tsPath, 'utf8')));
+  ts['ts-node'] = { compilerOptions: { paths: { '@cfg/*': ['./src/cfg/*'] } } };
+  fs.writeFileSync(tsPath, JSON.stringify(ts, null, 2));
+}
+
+// ng new's tsconfig.json contains // comments; strip them so JSON.parse works.
+function stripJsonComments(text) {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function main() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'loader-mig-'));
+  if (
+    run(
+      NG_BIN,
+      [
+        'new',
+        APP,
+        '--directory',
+        APP,
+        '--skip-install',
+        '--skip-git',
+        '--routing=false',
+        '--style=scss',
+      ],
+      { cwd: tmp }
+    ) !== 0
+  ) {
+    throw new Error('ng new failed');
+  }
+  const workdir = path.join(tmp, APP);
+  fs.symlinkSync(path.join(REPO_ROOT, 'node_modules'), path.join(workdir, 'node_modules'), 'dir');
+
+  seedPreJitiShape(workdir);
+
+  const shimDir = makePackageManagerShim();
+  const env = { ...process.env, PATH: `${shimDir}${path.delimiter}${process.env.PATH}` };
+
+  const status = run(
+    NG_BIN,
+    [
+      'update',
+      '@angular-builders/custom-webpack',
+      '--migrate-only',
+      '--from=21.0.0',
+      '--to=22.0.0',
+      '--allow-dirty',
+      '--force',
+    ],
+    { cwd: workdir, env }
+  );
+  if (status !== 0) throw new Error(`ng update --migrate-only failed with status ${status}`);
+
+  // Assert the transforms landed.
+  const pkg = JSON.parse(fs.readFileSync(path.join(workdir, 'package.json'), 'utf8'));
+  if (/ts-node\/esm|NODE_OPTIONS/.test(pkg.scripts['build-ts'])) {
+    throw new Error(
+      `build-ts script still has the ts-node/esm workaround: ${pkg.scripts['build-ts']}`
+    );
+  }
+  if (pkg.devDependencies['ts-node'] !== undefined)
+    throw new Error('ts-node devDependency not removed');
+  if (pkg.devDependencies['tsconfig-paths'] !== undefined) {
+    throw new Error('tsconfig-paths devDependency not removed');
+  }
+
+  const ts = JSON.parse(fs.readFileSync(path.join(workdir, 'tsconfig.json'), 'utf8'));
+  if (ts['ts-node'] !== undefined) throw new Error('obsolete ts-node tsconfig section not removed');
+  const paths = (ts.compilerOptions && ts.compilerOptions.paths) || {};
+  if (JSON.stringify(paths['@cfg/*']) !== JSON.stringify(['./src/cfg/*'])) {
+    throw new Error('ts-node section paths were not lifted into compilerOptions');
+  }
+  console.log('[loader-migration] transform assertions OK');
+
+  // Prove the migrated workspace builds and the .ts webpack config loads via jiti.
+  if (run('sh', ['-c', 'npx ng build'], { cwd: workdir, env }) !== 0) {
+    throw new Error('ng build failed post-migration');
+  }
+
+  console.log('[loader-migration] PASS');
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`[loader-migration] FAIL: ${err.message}`);
+  process.exit(1);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,6 +193,7 @@ __metadata:
     "@angular-devkit/schematics": ^22.0.0-rc.2
     "@schematics/angular": ^22.0.0-rc.2
     copyfiles: ^2.4.1
+    get-tsconfig: ^4.10.0
     jiti: ^2.7.0
     rimraf: ^6.0.0
     typescript: 6.0.3
@@ -12588,6 +12589,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-tsconfig@npm:^4.10.0":
+  version: 4.14.0
+  resolution: "get-tsconfig@npm:4.14.0"
+  dependencies:
+    resolve-pkg-maps: ^1.0.0
+  checksum: d3b757791338a0ce419d741e0600e0d3c6f14cac92fd7db7bb050421680ceeb127d306f5022e8fd660a918e2d5a69db0bb8b0dd2ea3f265e0bbedc4674abccf8
+  languageName: node
+  linkType: hard
+
 "get-uri@npm:^6.0.1":
   version: 6.0.5
   resolution: "get-uri@npm:6.0.5"
@@ -18251,6 +18261,13 @@ __metadata:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 4ceeb9113e1b1372d0cd969f3468fa042daa1dd9527b1b6bb88acb6ab55d8b9cd65dbf18819f9f9ddf0db804990901dcdaade80a215e7b2c23daae38e64f5bdf
+  languageName: node
+  linkType: hard
+
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 1012afc566b3fdb190a6309cc37ef3b2dcc35dff5fa6683a9d00cd25c3247edfbc4691b91078c97adc82a29b77a2660c30d791d65dab4fc78bfc473f60289977
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,7 +214,6 @@ __metadata:
     esbuild: 0.28.0
     jest: 30.4.2
     rimraf: ^6.0.0
-    ts-node: ^10.0.0
     typescript: 6.0.3
   peerDependencies:
     "@angular/compiler-cli": ^22.0.0-rc.2
@@ -238,7 +237,6 @@ __metadata:
     jest: 30.4.2
     lodash: ^4.17.15
     rimraf: ^6.0.0
-    ts-node: ^10.0.0
     typescript: 6.0.3
     webpack-merge: ^6.0.0
   peerDependencies:
@@ -8385,6 +8383,7 @@ __metadata:
     "@types/lodash": ^4.14.118
     "@types/node": ^24.0.0
     husky: ^9.0.0
+    jiti: ^2.7.0
     lint-staged: ^17.0.0
     lodash: ^4.17.15
     prettier: ^3.0.0
@@ -20539,7 +20538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node@npm:10.9.2, ts-node@npm:^10.0.0":
+"ts-node@npm:10.9.2":
   version: 10.9.2
   resolution: "ts-node@npm:10.9.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,9 +193,8 @@ __metadata:
     "@angular-devkit/schematics": ^22.0.0-rc.2
     "@schematics/angular": ^22.0.0-rc.2
     copyfiles: ^2.4.1
+    jiti: ^2.7.0
     rimraf: ^6.0.0
-    ts-node: ^10.0.0
-    tsconfig-paths: ^4.2.0
     typescript: 6.0.3
   languageName: unknown
   linkType: soft
@@ -14518,6 +14517,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jiti@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "jiti@npm:2.7.0"
+  bin:
+    jiti: lib/jiti-cli.mjs
+  checksum: e43d0859988f1f709a9a6c69833219ebdfe041fd2f7355a2a2151254c0c42b5a74de400f24d6b5d3d6689112fedae8be1ed4df29fcc1b891e8aa0992d33f3b16
+  languageName: node
+  linkType: hard
+
 "jose@npm:^6.1.3":
   version: 6.1.3
   resolution: "jose@npm:6.1.3"
@@ -14728,7 +14736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.2, json5@npm:^2.2.2, json5@npm:^2.2.3":
+"json5@npm:^2.1.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -19881,13 +19889,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-bom@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "strip-bom@npm:3.0.0"
-  checksum: 8d50ff27b7ebe5ecc78f1fe1e00fcdff7af014e73cf724b46fb81ef889eeb1015fc5184b64e81a2efe002180f3ba431bdd77e300da5c6685d702780fbf0c8d5b
-  languageName: node
-  linkType: hard
-
 "strip-bom@npm:^4.0.0":
   version: 4.0.0
   resolution: "strip-bom@npm:4.0.0"
@@ -20556,17 +20557,6 @@ __metadata:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: fde256c9073969e234526e2cfead42591b9a2aec5222bac154b0de2fa9e4ceb30efcd717ee8bc785a56f3a119bdd5aa27b333d9dbec94ed254bd26f8944c67ac
-  languageName: node
-  linkType: hard
-
-"tsconfig-paths@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "tsconfig-paths@npm:4.2.0"
-  dependencies:
-    json5: ^2.2.2
-    minimist: ^1.2.6
-    strip-bom: ^3.0.0
-  checksum: 28c5f7bbbcabc9dabd4117e8fdc61483f6872a1c6b02a4b1c4d68c5b79d06896c3cc9547610c4c3ba64658531caa2de13ead1ea1bf321c7b53e969c4752b98c7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3115,15 +3115,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cspotcode/source-map-support@npm:^0.8.0":
-  version: 0.8.1
-  resolution: "@cspotcode/source-map-support@npm:0.8.1"
-  dependencies:
-    "@jridgewell/trace-mapping": 0.3.9
-  checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
-  languageName: node
-  linkType: hard
-
 "@csstools/color-helpers@npm:^5.1.0":
   version: 5.1.0
   resolution: "@csstools/color-helpers@npm:5.1.0"
@@ -4662,7 +4653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
+"@jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 83b85f72c59d1c080b4cbec0fef84528963a1b5db34e4370fa4bd1e3ff64a0d80e0cee7369d11d73c704e0286fb2865b530acac7a871088fbe92b5edf1000870
@@ -4679,20 +4670,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
+"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: c2e36e67971f719a8a3a85ef5a5f580622437cc723c35d03ebd0c9c0b06418700ef006f58af742791f71f6a4fc68fcfaf1f6a74ec2f9a3332860e9373459dae7
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:0.3.9":
-  version: 0.3.9
-  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
-  dependencies:
-    "@jridgewell/resolve-uri": ^3.0.3
-    "@jridgewell/sourcemap-codec": ^1.4.10
-  checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
   languageName: node
   linkType: hard
 
@@ -6882,34 +6863,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node10@npm:^1.0.7":
-  version: 1.0.11
-  resolution: "@tsconfig/node10@npm:1.0.11"
-  checksum: 51fe47d55fe1b80ec35e6e5ed30a13665fd3a531945350aa74a14a1e82875fb60b350c2f2a5e72a64831b1b6bc02acb6760c30b3738b54954ec2dea82db7a267
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node12@npm:^1.0.7":
-  version: 1.0.11
-  resolution: "@tsconfig/node12@npm:1.0.11"
-  checksum: 5ce29a41b13e7897a58b8e2df11269c5395999e588b9a467386f99d1d26f6c77d1af2719e407621412520ea30517d718d5192a32403b8dfcc163bf33e40a338a
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node14@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "@tsconfig/node14@npm:1.0.3"
-  checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node16@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "@tsconfig/node16@npm:1.0.4"
-  checksum: 202319785901f942a6e1e476b872d421baec20cf09f4b266a1854060efbf78cde16a4d256e8bc949d31e6cd9a90f1e8ef8fb06af96a65e98338a2b6b0de0a0ff
-  languageName: node
-  linkType: hard
-
 "@tufjs/canonical-json@npm:2.0.0":
   version: 2.0.0
   resolution: "@tufjs/canonical-json@npm:2.0.0"
@@ -8214,15 +8167,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.1.1":
-  version: 8.3.4
-  resolution: "acorn-walk@npm:8.3.4"
-  dependencies:
-    acorn: ^8.11.0
-  checksum: 4ff03f42323e7cf90f1683e08606b0f460e1e6ac263d2730e3df91c7665b6f64e696db6ea27ee4bed18c2599569be61f28a8399fa170c611161a348c402ca19c
-  languageName: node
-  linkType: hard
-
 "acorn@npm:^7.1.1":
   version: 7.4.1
   resolution: "acorn@npm:7.4.1"
@@ -8232,7 +8176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.15.0, acorn@npm:^8.4.1":
+"acorn@npm:^8.15.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -8523,13 +8467,6 @@ __metadata:
   version: 2.2.0
   resolution: "arch@npm:2.2.0"
   checksum: e21b7635029fe8e9cdd5a026f9a6c659103e63fff423834323cdf836a1bb240a72d0c39ca8c470f84643385cf581bd8eda2cad8bf493e27e54bd9783abe9101f
-  languageName: node
-  linkType: hard
-
-"arg@npm:^4.1.0":
-  version: 4.1.3
-  resolution: "arg@npm:4.1.3"
-  checksum: 544af8dd3f60546d3e4aff084d451b96961d2267d668670199692f8d054f0415d86fc5497d0e641e91546f0aa920e7c29e5250e99fc89f5552a34b5d93b77f43
   languageName: node
   linkType: hard
 
@@ -10341,13 +10278,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-require@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "create-require@npm:1.1.1"
-  checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^6.0.0":
   version: 6.0.6
   resolution: "cross-spawn@npm:6.0.6"
@@ -10835,13 +10765,6 @@ __metadata:
   version: 0.0.1
   resolution: "di@npm:0.0.1"
   checksum: 3f09a99534d33e49264585db7f863ea8bc76c25c4d5a60df387c946018ecf1e1516b2c05a2092e5ca51fcdc08cefe609a6adc5253fa831626cb78cad4746505e
-  languageName: node
-  linkType: hard
-
-"diff@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "diff@npm:4.0.2"
-  checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
   languageName: node
   linkType: hard
 
@@ -15569,7 +15492,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-error@npm:^1.1.1, make-error@npm:^1.3.6":
+"make-error@npm:^1.3.6":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
@@ -20230,7 +20153,6 @@ __metadata:
     karma-jasmine: 5.1.0
     karma-jasmine-html-reporter: 2.2.0
     rxjs: 7.8.2
-    ts-node: 10.9.2
     tslib: 2.8.1
     typescript: 6.0.3
     typescript-eslint: 8.60.0
@@ -20529,44 +20451,6 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: 07ae4102569565ab57036f095152ea75c85032edf15379043ffc8da2dd0e6e93e84d0c50a24e10a5cddacb5ab773df0f3170f02db6c178edd22a5e485bc57dc7
-  languageName: node
-  linkType: hard
-
-"ts-node@npm:10.9.2":
-  version: 10.9.2
-  resolution: "ts-node@npm:10.9.2"
-  dependencies:
-    "@cspotcode/source-map-support": ^0.8.0
-    "@tsconfig/node10": ^1.0.7
-    "@tsconfig/node12": ^1.0.7
-    "@tsconfig/node14": ^1.0.0
-    "@tsconfig/node16": ^1.0.2
-    acorn: ^8.4.1
-    acorn-walk: ^8.1.1
-    arg: ^4.1.0
-    create-require: ^1.1.0
-    diff: ^4.0.1
-    make-error: ^1.1.1
-    v8-compile-cache-lib: ^3.0.1
-    yn: 3.1.1
-  peerDependencies:
-    "@swc/core": ">=1.2.50"
-    "@swc/wasm": ">=1.2.50"
-    "@types/node": "*"
-    typescript: ">=2.7"
-  peerDependenciesMeta:
-    "@swc/core":
-      optional: true
-    "@swc/wasm":
-      optional: true
-  bin:
-    ts-node: dist/bin.js
-    ts-node-cwd: dist/bin-cwd.js
-    ts-node-esm: dist/bin-esm.js
-    ts-node-script: dist/bin-script.js
-    ts-node-transpile-only: dist/bin-transpile.js
-    ts-script: dist/bin-script-deprecated.js
-  checksum: fde256c9073969e234526e2cfead42591b9a2aec5222bac154b0de2fa9e4ceb30efcd717ee8bc785a56f3a119bdd5aa27b333d9dbec94ed254bd26f8944c67ac
   languageName: node
   linkType: hard
 
@@ -21148,13 +21032,6 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
-  languageName: node
-  linkType: hard
-
-"v8-compile-cache-lib@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "v8-compile-cache-lib@npm:3.0.1"
-  checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
   languageName: node
   linkType: hard
 
@@ -22266,13 +22143,6 @@ __metadata:
     buffer-crc32: ~0.2.3
     pend: ~1.2.0
   checksum: 6b43f94e8ea9fd70ac2cd04e336dc0bbb423557b51b8f1de8fb9a04b2ca29723b8298f81f4386baac1114b236ea74bab2b4eb68aad75310d13ecf66e7216e648
-  languageName: node
-  linkType: hard
-
-"yn@npm:3.1.1":
-  version: 3.1.1
-  resolution: "yn@npm:3.1.1"
-  checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12468,7 +12468,6 @@ __metadata:
     karma-jasmine-html-reporter: 2.2.0
     puppeteer: 25.1.0
     rxjs: 7.8.2
-    ts-node: 10.9.2
     tslib: 2.8.1
     typescript: 6.0.3
     typescript-eslint: 8.60.0
@@ -16184,7 +16183,6 @@ __metadata:
     jsdom: 29.1.1
     ng-packagr: 22.0.0
     rxjs: 7.8.2
-    ts-node: 10.9.2
     tslib: 2.8.1
     typescript: 6.0.3
     typescript-eslint: 8.60.0
@@ -18772,7 +18770,6 @@ __metadata:
     karma-jasmine-html-reporter: 2.2.0
     puppeteer: 25.1.0
     rxjs: 7.8.2
-    ts-node: 10.9.2
     tslib: 2.8.1
     typescript: 6.0.3
     typescript-eslint: 8.60.0
@@ -18805,7 +18802,6 @@ __metadata:
     eslint: 10.4.1
     puppeteer: 25.1.0
     rxjs: 7.8.2
-    ts-node: 10.9.2
     tslib: 2.8.1
     typescript: 6.0.3
     typescript-eslint: 8.60.0
@@ -18839,7 +18835,6 @@ __metadata:
     eslint: 10.4.1
     puppeteer: 25.1.0
     rxjs: 7.8.2
-    ts-node: 10.9.2
     tslib: 2.8.1
     typescript: 6.0.3
     typescript-eslint: 8.60.0
@@ -19296,7 +19291,6 @@ __metadata:
     jest-junit: 17.0.0
     jsdom: 29.1.1
     rxjs: 7.8.2
-    ts-node: 10.9.2
     tslib: 2.8.1
     typescript: 6.0.3
     typescript-eslint: 8.60.0


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[x] Feature
[x] Build related changes
[x] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
```

## What is the current behavior?

User-provided TypeScript modules (webpack configs, esbuild plugins, index-html transformers, `jest.config.ts`) are loaded with **`ts-node`**, plus `tsconfig-paths` for path aliases and a hand-rolled `new Function('return import()')` workaround for ESM. This has several problems:

- **#1638** — `ts-node` is a hard dependency, installed for everyone (JS-only users pay for it too).
- **#1938** — loading `.ts` configs/plugins in ESM projects requires forcing `NODE_OPTIONS='--loader ts-node/esm'` (needs `cross-env`, bloats scripts, and `npx ng …` doesn't pick it up).
- `ts-node` registers once per process and is sticky — the first `tsConfig` wins; a different one logs a warning and is silently ignored.
- `ts-node`'s build-time type-checker is the root cause of the repo's recurring loader bugs (#2025 `moduleResolution`, #816 `resolveJsonModule`, TS5095/TS5110).
- `ts-node` is effectively unmaintained (last stable release Dec 2023; 11.0 ESM rewrite abandoned at beta).

Issue Number: #1938, #1638

## What is the new behavior?

`@angular-builders/common`'s `loadModule` now loads **all** module formats (`.ts`/`.mts`/`.cts`/`.js`/`.mjs`/`.cjs`) uniformly through **[jiti](https://github.com/unjs/jiti)**, collapsing the per-extension switch and deleting the `new Function` workaround.

- **#1938 fixed** — `.ts` configs/plugins load in ESM projects with plain `ng build`; no `NODE_OPTIONS`/`cross-env`.
- **#1638 addressed** — `ts-node` and `tsconfig-paths` are removed entirely (replaced by zero-dep `jiti` + tiny `get-tsconfig`). `ts-node` is no longer used anywhere in the repo, including the build (`merge-schemes.ts` now runs via jiti's CLI).
- **Sticky-tsconfig gone** — each `tsConfig` gets its own isolated jiti instance.
- Path aliases (`baseUrl`/`paths`) are resolved from the exact `tsConfig` via `get-tsconfig` (jiti's built-in `tsconfigPaths` only honors files literally named `tsconfig.json`, which would silently mis-resolve real targets like `tsconfig.app.json`).

**Design/decision spec and implementation plan:** see `docs/superpowers/specs/2026-06-07-loader-modernization-design.md` (these working docs are intentionally not committed).

Verified: full unit suite (24 suites / 156 tests) + integration tests for `.ts` config/plugin loading across CJS/ESM, JSON imports (#816), subpath `moduleResolution: bundler` (#2025), and `jest.config.ts` — all green with `ts-node` absent.

## Does this PR introduce a breaking change?

```
[x] Yes
```

- **Build-time type-checking of TS configs/plugins is removed.** A config with a *type* error that previously failed `ng build` now transpiles and runs. Editor type-checking is unaffected. Migration: run `tsc --noEmit -p <tsconfig that includes your config files>` in CI (documented in both package READMEs).
- **`ts-node` / `tsconfig-paths` are no longer installed** by the builder packages. Anyone relying on the transitive install must add them explicitly.
- The `ts-node`-section-of-tsconfig mechanism for per-transform compiler options is gone (jiti reads the target tsconfig directly).

Aligned with the v22 major; landing on `release/v22` ahead of Angular 22 GA.

## Other information

Applying `ci:full` — changes touch `common`, root configs, and the build pipeline, where Turbo's affected-package filter may miss downstream breakage.
