### PR TITLE
ci: protect publish from self-cancel + add from-package recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,22 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type'
+        description: 'Release type (recover = re-publish packages missing from the registry)'
         required: true
         default: 'beta'
         type: choice
-        options: [beta, graduate]
+        options: [beta, graduate, recover]
 
-# Scope the concurrency group by event_name so a push-triggered run cannot cancel a
-# workflow_dispatch run (and vice versa). A graduation/beta publish pushes the
-# `ci(release): publish` commit to master mid-job; without event_name in the key, that
-# push spawns a same-group run that cancels the still-running publish (lerna pushes git
-# tags BEFORE npm publish, so the kill can land mid-publish -> tags pushed, packages not).
+# Cancel superseded in-progress runs (rapid pushes / PR re-pushes) as usual, EXCEPT the
+# `ci(release): publish` commit that a beta/graduate publish pushes to master mid-job. That
+# push would otherwise spawn a same-group run that cancels the still-running publish — and
+# since lerna pushes git tags BEFORE the per-package npm publish loop, the kill can land
+# mid-loop (tags pushed, packages not; this is how the v22 beta published only 2 of 6).
+# Excluding ci(release) commits (same guard as the build job's skip) keeps normal
+# cancellation while letting an in-flight publish run to completion.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.event.head_commit.message, 'ci(release)') }}
 
 # Karma uses the runner's preinstalled system Chrome (see karma.conf.js), so Puppeteer's
 # bundled Chrome is unused. Skip its download to avoid install-time failures when the
@@ -162,6 +164,10 @@ jobs:
           git config --global user.email ${{ secrets.GIT_EMAIL }}
           if [ "${{ github.event.inputs.release_type }}" == "graduate" ]; then
             yarn graduate --yes
+          elif [ "${{ github.event.inputs.release_type }}" == "recover" ]; then
+            # Recover a partial publish: publish only packages whose current version
+            # (from package.json) isn't on the registry yet. No version bump, no new tags.
+            yarn lerna publish from-package --dist-tag=next --yes
           else
             bash scripts/default-registry.sh
           fi


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features) — N/A (CI workflow change)
- [x] Docs have been added / updated (for bug fixes / features) — inline comments in `ci.yml`

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
```

## What is the current behavior?

**1. Publish runs self-cancel.** A beta publish (push to master) runs `lerna publish`, which pushes the `ci(release): publish` commit to master *mid-job*. That push spawns a new run in the same concurrency group (`ci-push-refs/heads/master`); with unconditional `cancel-in-progress: true`, it cancels the still-running publish. Because lerna pushes git tags **before** the per-package `npm publish` loop, the kill can land mid-loop — tags pushed, packages not. This is exactly how the v22 beta published only **2 of 6** packages.

The prior `e2a077dd` fix scoped the group by `event_name`, which protects `workflow_dispatch` (graduate) from a push — but a beta publish **is** a push on master, so the publish commit's own push shares the group and still self-cancels.

**2. No recovery path for a partial publish.** Once a publish is interrupted, the existing `beta`/`graduate` commands (conventional-prerelease) can't cleanly re-publish the missing packages (versions are already bumped and tagged).

## What is the new behavior?

1. **`cancel-in-progress` excludes `ci(release)` commits** (same guard as the build job's skip): superseded PR/push runs still cancel as before, but an in-flight publish runs to completion.
2. **New `recover` `workflow_dispatch` release type** runs `lerna publish from-package --dist-tag=next --yes`, re-publishing only packages whose current version is missing from the registry — no version bump, no new tags, via the same OIDC trusted publishing (no local npm token).

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Used to recover the v22 beta (4 packages missing from npm after the self-cancel), and prevents recurrence on future beta publishes and graduation.
