### PR TITLE
docs(changelog): clean up v22 breaking-change sections

### DIFF
--- a/packages/bazel/CHANGELOG.md
+++ b/packages/bazel/CHANGELOG.md
@@ -7,11 +7,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) (#2264)
+- All packages now require Angular 22.
 
 ### Features
 
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
+- upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
 
 ## [21.0.4](https://github.com/just-jeb/angular-builders/compare/@angular-builders/bazel@21.0.4-beta.6...@angular-builders/bazel@21.0.4) (2026-06-08)
 
@@ -21,13 +21,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Reverts
 
-* remove redundant TS2742 builder annotations ([#2275](https://github.com/just-jeb/angular-builders/issues/2275), [#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([#2279](https://github.com/just-jeb/angular-builders/issues/2279)) ([a2882e5](https://github.com/just-jeb/angular-builders/commit/a2882e511ae2fa44dc445dbc9e73882de70981b5))
+- remove redundant TS2742 builder annotations ([#2275](https://github.com/just-jeb/angular-builders/issues/2275), [#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([#2279](https://github.com/just-jeb/angular-builders/issues/2279)) ([a2882e5](https://github.com/just-jeb/angular-builders/commit/a2882e511ae2fa44dc445dbc9e73882de70981b5))
 
 ## [21.0.4-beta.5](https://github.com/just-jeb/angular-builders/compare/@angular-builders/bazel@21.0.4-beta.4...@angular-builders/bazel@21.0.4-beta.5) (2026-06-04)
 
 ### Bug Fixes
 
-* **builders:** annotate builder default exports with Builder<T> to avoid TS2742 ([#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([7db3848](https://github.com/just-jeb/angular-builders/commit/7db3848c7c3bf8362904130cbab8c7711cdac4ed))
+- **builders:** annotate builder default exports with Builder<T> to avoid TS2742 ([#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([7db3848](https://github.com/just-jeb/angular-builders/commit/7db3848c7c3bf8362904130cbab8c7711cdac4ed))
 
 ## [21.0.4-beta.4](https://github.com/just-jeb/angular-builders/compare/@angular-builders/bazel@21.0.4-beta.3...@angular-builders/bazel@21.0.4-beta.4) (2026-02-18)
 
@@ -47,7 +47,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## <small>21.0.4-beta.0 (2026-01-16)</small>
 
-* ci: revamp CI/CD with parallel matrix jobs (#1980) ([8de5b74](https://github.com/just-jeb/angular-builders/commit/8de5b74)), closes [#1980](https://github.com/just-jeb/angular-builders/issues/1980)
+- ci: revamp CI/CD with parallel matrix jobs (#1980) ([8de5b74](https://github.com/just-jeb/angular-builders/commit/8de5b74)), closes [#1980](https://github.com/just-jeb/angular-builders/issues/1980)
 
 ## <small>21.0.3 (2026-01-14)</small>
 
@@ -55,8 +55,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## <small>21.0.3-beta.0 (2026-01-14)</small>
 
-* ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
-* ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
+- ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
+- ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
 
 ## [21.0.2](https://github.com/just-jeb/angular-builders/compare/@angular-builders/bazel@21.0.1-beta.0...@angular-builders/bazel@21.0.2) (2026-01-13)
 
@@ -78,21 +78,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 21
+- All packages now require Angular 21
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [21.0.0-beta.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/bazel@20.0.1-beta.1...@angular-builders/bazel@21.0.0-beta.0) (2025-12-17)
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 21
+- All packages now require Angular 21
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [20.0.1-beta.1](https://github.com/just-jeb/angular-builders/compare/@angular-builders/bazel@20.0.1-beta.0...@angular-builders/bazel@20.0.1-beta.1) (2025-11-13)
 
@@ -110,11 +110,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** upgrade to Angular 20
+- **deps:** upgrade to Angular 20
 
 ### Miscellaneous Chores
 
-* **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
+- **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
 
 ## [19.0.1](https://github.com/just-jeb/angular-builders/compare/@angular-builders/bazel@19.0.1-beta.0...@angular-builders/bazel@19.0.1) (2025-04-07)
 
@@ -132,11 +132,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** update to Angular 19 (#1871)
+- **deps:** update to Angular 19 (#1871)
 
 ### Miscellaneous Chores
 
-* **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
+- **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
 
 ## [18.0.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/bazel@18.0.0-beta.3...@angular-builders/bazel@18.0.0) (2024-06-17)
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -7,42 +7,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* TypeScript configs/plugins are now transpiled (no build-time
-type-checking). Run `tsc --noEmit` separately to type-check config files.
-
-* test(custom-webpack,custom-esbuild,jest): mock loadModule instead of faking config files
-
-The jiti-based loader loads modules outside Jest's module registry, so specs can no
-longer fake user config files via jest.mock(path, {virtual:true}). Mock common's
-loadModule instead (loading is covered by common's own load-module.spec). Also drops
-the obsolete ts-node register-once/warn assertions, which no longer apply.
-
-* build!: run merge-schemes.ts via jiti and remove ts-node entirely
-
-merge-schemes.ts was executed with ts-node at build time; run it with jiti's CLI
-instead (added as a root devDependency) and drop ts-node from custom-webpack and
-custom-esbuild. ts-node is no longer used anywhere in the repo.
-* ts-node is no longer a dependency of @angular-builders packages.
-
-* test(examples): drop ts-node and ts-node/esm NODE_OPTIONS workaround
-
-TypeScript configs/plugins now load via jiti through the builders, so the ESM apps
-no longer need TS_NODE_PROJECT/NODE_OPTIONS='--loader ts-node/esm', and no example
-needs ts-node. Verified by the ts-config / esm / json-import / bundler-resolution
-integration tests passing with ts-node absent.
-
-* docs: update AGENTS.md and READMEs for jiti loader
-
-Reflect the jiti-based loader: drop ts-node/tsconfig-paths references and the
-ESM NODE_OPTIONS workaround, document transpile-only loading + tsc --noEmit
-type-check guidance, and record the get-tsconfig alias-resolution rationale.
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) (#2264)
+- All packages now require Angular 22.
+- User TypeScript config/plugin modules now load via `jiti` instead of `ts-node`. Configs are transpiled rather than type-checked (run `tsc --noEmit` separately if you relied on build-time type-checking); `ts-node` and `tsconfig-paths` are no longer dependencies; and the `NODE_OPTIONS='--loader ts-node/esm'` workaround for ESM apps is no longer needed.
 
 ### Features
 
-* ng add / ng update schematics for jest, custom-esbuild, custom-webpack ([#2267](https://github.com/just-jeb/angular-builders/issues/2267)) ([062f423](https://github.com/just-jeb/angular-builders/commit/062f423cbe2f87d97017ef4801cf6afb209f9191)), closes [2191/#2212](https://github.com/2191/angular-builders/issues/2212) [#2260](https://github.com/just-jeb/angular-builders/issues/2260) [#2212](https://github.com/just-jeb/angular-builders/issues/2212) [#2260](https://github.com/just-jeb/angular-builders/issues/2260)
-* replace ts-node with jiti for loading TypeScript modules ([#2287](https://github.com/just-jeb/angular-builders/issues/2287)) ([0348e06](https://github.com/just-jeb/angular-builders/commit/0348e06df73f57e62a8803a20c8b7b66b664a5d0)), closes [#816](https://github.com/just-jeb/angular-builders/issues/816)
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
+- ng add / ng update schematics for jest, custom-esbuild, custom-webpack ([#2267](https://github.com/just-jeb/angular-builders/issues/2267)) ([062f423](https://github.com/just-jeb/angular-builders/commit/062f423cbe2f87d97017ef4801cf6afb209f9191)), closes [#22](https://github.com/just-jeb/angular-builders/issues/22)
+- replace ts-node with jiti for loading TypeScript modules ([#2287](https://github.com/just-jeb/angular-builders/issues/2287)) ([0348e06](https://github.com/just-jeb/angular-builders/commit/0348e06df73f57e62a8803a20c8b7b66b664a5d0)), closes [#816](https://github.com/just-jeb/angular-builders/issues/816)
+- upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
 
 ## [5.0.4](https://github.com/just-jeb/angular-builders/compare/@angular-builders/common@5.0.4-beta.4...@angular-builders/common@5.0.4) (2026-06-08)
 
@@ -52,13 +24,13 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### Bug Fixes
 
-* **common:** add resolveJsonModule to ts-node compilerOptions (fixes [#816](https://github.com/just-jeb/angular-builders/issues/816)) ([#2189](https://github.com/just-jeb/angular-builders/issues/2189)) ([6b16727](https://github.com/just-jeb/angular-builders/commit/6b16727b2c4c2298418484fe346b5db931764fbb))
+- **common:** add resolveJsonModule to ts-node compilerOptions (fixes [#816](https://github.com/just-jeb/angular-builders/issues/816)) ([#2189](https://github.com/just-jeb/angular-builders/issues/2189)) ([6b16727](https://github.com/just-jeb/angular-builders/commit/6b16727b2c4c2298418484fe346b5db931764fbb))
 
 ## [5.0.4-beta.3](https://github.com/just-jeb/angular-builders/compare/@angular-builders/common@5.0.4-beta.2...@angular-builders/common@5.0.4-beta.3) (2026-04-26)
 
 ### Bug Fixes
 
-* **common:** remove moduleResolution override in ts-node register (fixes [#2025](https://github.com/just-jeb/angular-builders/issues/2025)) ([#2187](https://github.com/just-jeb/angular-builders/issues/2187)) ([a0daa6a](https://github.com/just-jeb/angular-builders/commit/a0daa6a9730c4f918667f5f9a99dc373a41c1382))
+- **common:** remove moduleResolution override in ts-node register (fixes [#2025](https://github.com/just-jeb/angular-builders/issues/2025)) ([#2187](https://github.com/just-jeb/angular-builders/issues/2187)) ([a0daa6a](https://github.com/just-jeb/angular-builders/commit/a0daa6a9730c4f918667f5f9a99dc373a41c1382))
 
 ## [5.0.4-beta.2](https://github.com/just-jeb/angular-builders/compare/@angular-builders/common@5.0.4-beta.1...@angular-builders/common@5.0.4-beta.2) (2026-02-23)
 
@@ -78,12 +50,12 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ## <small>5.0.3-beta.1 (2026-01-14)</small>
 
-* fix(common): add missing repository field for npm provenance validation (#1979) ([7c83889](https://github.com/just-jeb/angular-builders/commit/7c83889)), closes [#1979](https://github.com/just-jeb/angular-builders/issues/1979)
+- fix(common): add missing repository field for npm provenance validation (#1979) ([7c83889](https://github.com/just-jeb/angular-builders/commit/7c83889)), closes [#1979](https://github.com/just-jeb/angular-builders/issues/1979)
 
 ## <small>5.0.3-beta.0 (2026-01-14)</small>
 
-* ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
-* ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
+- ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
+- ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
 
 ## [5.0.2](https://github.com/just-jeb/angular-builders/compare/@angular-builders/common@5.0.1-beta.0...@angular-builders/common@5.0.2) (2026-01-13)
 
@@ -105,63 +77,67 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### ⚠ BREAKING CHANGES
 
-* **jest:** Requires Jest 30
+- **jest:** Requires Jest 30
 
 Users must upgrade:
 npm install --save-dev jest@^30.0.0 jest-environment-jsdom@^30.0.0 jsdom@^26.0.0
 
 Also requires tsconfig.spec.json update for moduleResolution compatibility:
 {
-  "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "isolatedModules": true
-  }
+"compilerOptions": {
+"module": "Node16",
+"moduleResolution": "Node16",
+"isolatedModules": true
+}
 }
 
 Schema changes:
+
 - testPathPattern renamed to testPathPatterns
 - Removed: browser, init, mapCoverage, testURL, timers
+
 * All packages now require Angular 21
 
 ### Features
 
-* **jest:** upgrade to Jest 30 via jest-preset-angular v16 ([ca4b6d9](https://github.com/just-jeb/angular-builders/commit/ca4b6d91372ff0bc2c827135a9f3ce2b4bc3e0f9)), closes [#1931](https://github.com/just-jeb/angular-builders/issues/1931)
+- **jest:** upgrade to Jest 30 via jest-preset-angular v16 ([ca4b6d9](https://github.com/just-jeb/angular-builders/commit/ca4b6d91372ff0bc2c827135a9f3ce2b4bc3e0f9)), closes [#1931](https://github.com/just-jeb/angular-builders/issues/1931)
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [5.0.0-beta.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/common@4.0.1-beta.0...@angular-builders/common@5.0.0-beta.0) (2025-12-17)
 
 ### ⚠ BREAKING CHANGES
 
-* **jest:** Requires Jest 30
+- **jest:** Requires Jest 30
 
 Users must upgrade:
 npm install --save-dev jest@^30.0.0 jest-environment-jsdom@^30.0.0 jsdom@^26.0.0
 
 Also requires tsconfig.spec.json update for moduleResolution compatibility:
 {
-  "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "isolatedModules": true
-  }
+"compilerOptions": {
+"module": "Node16",
+"moduleResolution": "Node16",
+"isolatedModules": true
+}
 }
 
 Schema changes:
+
 - testPathPattern renamed to testPathPatterns
 - Removed: browser, init, mapCoverage, testURL, timers
+
 * All packages now require Angular 21
 
 ### Features
 
-* **jest:** upgrade to Jest 30 via jest-preset-angular v16 ([ca4b6d9](https://github.com/just-jeb/angular-builders/commit/ca4b6d91372ff0bc2c827135a9f3ce2b4bc3e0f9)), closes [#1931](https://github.com/just-jeb/angular-builders/issues/1931)
+- **jest:** upgrade to Jest 30 via jest-preset-angular v16 ([ca4b6d9](https://github.com/just-jeb/angular-builders/commit/ca4b6d91372ff0bc2c827135a9f3ce2b4bc3e0f9)), closes [#1931](https://github.com/just-jeb/angular-builders/issues/1931)
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [4.0.1-beta.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/common@4.0.0...@angular-builders/common@4.0.1-beta.0) (2025-11-13)
 
@@ -175,15 +151,15 @@ Schema changes:
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** upgrade to Angular 20
+- **deps:** upgrade to Angular 20
 
 ### Features
 
-* migrate to @angular/build ([db2fc68](https://github.com/just-jeb/angular-builders/commit/db2fc689cf58be44bcbee6a13e9729ec88138e1b))
+- migrate to @angular/build ([db2fc68](https://github.com/just-jeb/angular-builders/commit/db2fc689cf58be44bcbee6a13e9729ec88138e1b))
 
 ### Miscellaneous Chores
 
-* **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
+- **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
 
 ## [3.0.1](https://github.com/just-jeb/angular-builders/compare/@angular-builders/common@3.0.1-beta.0...@angular-builders/common@3.0.1) (2025-04-07)
 
@@ -201,11 +177,11 @@ Schema changes:
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** update to Angular 19 (#1871)
+- **deps:** update to Angular 19 (#1871)
 
 ### Miscellaneous Chores
 
-* **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
+- **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
 
 ## [2.0.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/common@2.0.0-beta.1...@angular-builders/common@2.0.0) (2024-06-17)
 

--- a/packages/custom-esbuild/CHANGELOG.md
+++ b/packages/custom-esbuild/CHANGELOG.md
@@ -7,47 +7,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 22
-* TypeScript configs/plugins are now transpiled (no build-time
-type-checking). Run `tsc --noEmit` separately to type-check config files.
-
-* test(custom-webpack,custom-esbuild,jest): mock loadModule instead of faking config files
-
-The jiti-based loader loads modules outside Jest's module registry, so specs can no
-longer fake user config files via jest.mock(path, {virtual:true}). Mock common's
-loadModule instead (loading is covered by common's own load-module.spec). Also drops
-the obsolete ts-node register-once/warn assertions, which no longer apply.
-
-* build!: run merge-schemes.ts via jiti and remove ts-node entirely
-
-merge-schemes.ts was executed with ts-node at build time; run it with jiti's CLI
-instead (added as a root devDependency) and drop ts-node from custom-webpack and
-custom-esbuild. ts-node is no longer used anywhere in the repo.
-* ts-node is no longer a dependency of @angular-builders packages.
-
-* test(examples): drop ts-node and ts-node/esm NODE_OPTIONS workaround
-
-TypeScript configs/plugins now load via jiti through the builders, so the ESM apps
-no longer need TS_NODE_PROJECT/NODE_OPTIONS='--loader ts-node/esm', and no example
-needs ts-node. Verified by the ts-config / esm / json-import / bundler-resolution
-integration tests passing with ts-node absent.
-
-* docs: update AGENTS.md and READMEs for jiti loader
-
-Reflect the jiti-based loader: drop ts-node/tsconfig-paths references and the
-ESM NODE_OPTIONS workaround, document transpile-only loading + tsc --noEmit
-type-check guidance, and record the get-tsconfig alias-resolution rationale.
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) (#2264)
+- All packages now require Angular 22.
+- User TypeScript config/plugin modules now load via `jiti` instead of `ts-node`. Configs are transpiled rather than type-checked (run `tsc --noEmit` separately if you relied on build-time type-checking); `ts-node` and `tsconfig-paths` are no longer dependencies; and the `NODE_OPTIONS='--loader ts-node/esm'` workaround for ESM apps is no longer needed.
 
 ### Features
 
-* ng add / ng update schematics for jest, custom-esbuild, custom-webpack ([#2267](https://github.com/just-jeb/angular-builders/issues/2267)) ([062f423](https://github.com/just-jeb/angular-builders/commit/062f423cbe2f87d97017ef4801cf6afb209f9191)), closes [2191/#2212](https://github.com/2191/angular-builders/issues/2212) [#2260](https://github.com/just-jeb/angular-builders/issues/2260) [#2212](https://github.com/just-jeb/angular-builders/issues/2212) [#2260](https://github.com/just-jeb/angular-builders/issues/2260)
-* replace ts-node with jiti for loading TypeScript modules ([#2287](https://github.com/just-jeb/angular-builders/issues/2287)) ([0348e06](https://github.com/just-jeb/angular-builders/commit/0348e06df73f57e62a8803a20c8b7b66b664a5d0)), closes [#816](https://github.com/just-jeb/angular-builders/issues/816)
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
+- ng add / ng update schematics for jest, custom-esbuild, custom-webpack ([#2267](https://github.com/just-jeb/angular-builders/issues/2267)) ([062f423](https://github.com/just-jeb/angular-builders/commit/062f423cbe2f87d97017ef4801cf6afb209f9191)), closes [#22](https://github.com/just-jeb/angular-builders/issues/22)
+- replace ts-node with jiti for loading TypeScript modules ([#2287](https://github.com/just-jeb/angular-builders/issues/2287)) ([0348e06](https://github.com/just-jeb/angular-builders/commit/0348e06df73f57e62a8803a20c8b7b66b664a5d0)), closes [#816](https://github.com/just-jeb/angular-builders/issues/816)
+- upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
 
 ### Miscellaneous Chores
 
-* graduate Angular 22 from RC to GA ([daec882](https://github.com/just-jeb/angular-builders/commit/daec8828f1dcd34c989af6ae782a431b3f3205ee))
+- graduate Angular 22 from RC to GA ([daec882](https://github.com/just-jeb/angular-builders/commit/daec8828f1dcd34c989af6ae782a431b3f3205ee))
 
 ## [21.1.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@21.1.0-beta.16...@angular-builders/custom-esbuild@21.1.0) (2026-06-08)
 
@@ -57,13 +28,13 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### Reverts
 
-* remove redundant TS2742 builder annotations ([#2275](https://github.com/just-jeb/angular-builders/issues/2275), [#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([#2279](https://github.com/just-jeb/angular-builders/issues/2279)) ([a2882e5](https://github.com/just-jeb/angular-builders/commit/a2882e511ae2fa44dc445dbc9e73882de70981b5))
+- remove redundant TS2742 builder annotations ([#2275](https://github.com/just-jeb/angular-builders/issues/2275), [#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([#2279](https://github.com/just-jeb/angular-builders/issues/2279)) ([a2882e5](https://github.com/just-jeb/angular-builders/commit/a2882e511ae2fa44dc445dbc9e73882de70981b5))
 
 ## [21.1.0-beta.15](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@21.1.0-beta.14...@angular-builders/custom-esbuild@21.1.0-beta.15) (2026-06-04)
 
 ### Bug Fixes
 
-* **builders:** annotate builder default exports with Builder<T> to avoid TS2742 ([#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([7db3848](https://github.com/just-jeb/angular-builders/commit/7db3848c7c3bf8362904130cbab8c7711cdac4ed))
+- **builders:** annotate builder default exports with Builder<T> to avoid TS2742 ([#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([7db3848](https://github.com/just-jeb/angular-builders/commit/7db3848c7c3bf8362904130cbab8c7711cdac4ed))
 
 ## [21.1.0-beta.14](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@21.1.0-beta.13...@angular-builders/custom-esbuild@21.1.0-beta.14) (2026-06-01)
 
@@ -89,7 +60,7 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### Bug Fixes
 
-* **deps:** add rxjs>=7 as peer dependency to custom-esbuild, custom-webpack, and jest (fixes [#1863](https://github.com/just-jeb/angular-builders/issues/1863)) ([#2188](https://github.com/just-jeb/angular-builders/issues/2188)) ([2e067f5](https://github.com/just-jeb/angular-builders/commit/2e067f51eb3efb65fbef7050b8a10c499a585f0a))
+- **deps:** add rxjs>=7 as peer dependency to custom-esbuild, custom-webpack, and jest (fixes [#1863](https://github.com/just-jeb/angular-builders/issues/1863)) ([#2188](https://github.com/just-jeb/angular-builders/issues/2188)) ([2e067f5](https://github.com/just-jeb/angular-builders/commit/2e067f51eb3efb65fbef7050b8a10c499a585f0a))
 
 ## [21.1.0-beta.8](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@21.1.0-beta.7...@angular-builders/custom-esbuild@21.1.0-beta.8) (2026-04-24)
 
@@ -125,11 +96,11 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ## 21.1.0-beta.0 (2026-01-18)
 
-* feat(ci): add Turborepo for affected detection (#1981) ([884098b](https://github.com/just-jeb/angular-builders/commit/884098b)), closes [#1981](https://github.com/just-jeb/angular-builders/issues/1981)
+- feat(ci): add Turborepo for affected detection (#1981) ([884098b](https://github.com/just-jeb/angular-builders/commit/884098b)), closes [#1981](https://github.com/just-jeb/angular-builders/issues/1981)
 
 ## <small>21.0.4-beta.0 (2026-01-16)</small>
 
-* ci: revamp CI/CD with parallel matrix jobs (#1980) ([8de5b74](https://github.com/just-jeb/angular-builders/commit/8de5b74)), closes [#1980](https://github.com/just-jeb/angular-builders/issues/1980)
+- ci: revamp CI/CD with parallel matrix jobs (#1980) ([8de5b74](https://github.com/just-jeb/angular-builders/commit/8de5b74)), closes [#1980](https://github.com/just-jeb/angular-builders/issues/1980)
 
 ## <small>21.0.3 (2026-01-14)</small>
 
@@ -141,8 +112,8 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ## <small>21.0.3-beta.0 (2026-01-14)</small>
 
-* ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
-* ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
+- ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
+- ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
 
 ## [21.0.2](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@21.0.1-beta.0...@angular-builders/custom-esbuild@21.0.2) (2026-01-13)
 
@@ -164,21 +135,21 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 21
+- All packages now require Angular 21
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [21.0.0-beta.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@20.1.0-beta.1...@angular-builders/custom-esbuild@21.0.0-beta.0) (2025-12-17)
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 21
+- All packages now require Angular 21
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [20.1.0-beta.1](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@20.1.0-beta.0...@angular-builders/custom-esbuild@20.1.0-beta.1) (2025-11-13)
 
@@ -188,7 +159,7 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### Features
 
-* **custom-esbuild:** add `unit-test` builder ([#1935](https://github.com/just-jeb/angular-builders/issues/1935)) ([00972a8](https://github.com/just-jeb/angular-builders/commit/00972a880d4747c521d4aa5f03b7268ec0b43e29))
+- **custom-esbuild:** add `unit-test` builder ([#1935](https://github.com/just-jeb/angular-builders/issues/1935)) ([00972a8](https://github.com/just-jeb/angular-builders/commit/00972a880d4747c521d4aa5f03b7268ec0b43e29))
 
 ## [20.0.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@20.0.0-beta.0...@angular-builders/custom-esbuild@20.0.0) (2025-06-25)
 
@@ -198,16 +169,16 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** upgrade to Angular 20
+- **deps:** upgrade to Angular 20
 
 ### Features
 
-* **custom-esbuild:** expose builder options to plugins ([2c114d9](https://github.com/just-jeb/angular-builders/commit/2c114d9ccf105d8bbf024de9e67a69d625ce2742))
-* migrate to @angular/build ([db2fc68](https://github.com/just-jeb/angular-builders/commit/db2fc689cf58be44bcbee6a13e9729ec88138e1b))
+- **custom-esbuild:** expose builder options to plugins ([2c114d9](https://github.com/just-jeb/angular-builders/commit/2c114d9ccf105d8bbf024de9e67a69d625ce2742))
+- migrate to @angular/build ([db2fc68](https://github.com/just-jeb/angular-builders/commit/db2fc689cf58be44bcbee6a13e9729ec88138e1b))
 
 ### Miscellaneous Chores
 
-* **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
+- **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
 
 ## [19.1.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@19.1.0-beta.2...@angular-builders/custom-esbuild@19.1.0) (2025-04-07)
 
@@ -225,7 +196,7 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### Features
 
-* **custom-esbuild:** expose current target to index html transform ([#1877](https://github.com/just-jeb/angular-builders/issues/1877)) ([78e2006](https://github.com/just-jeb/angular-builders/commit/78e200609bbdbc7d5d9bc76f5675283bdefc871b))
+- **custom-esbuild:** expose current target to index html transform ([#1877](https://github.com/just-jeb/angular-builders/issues/1877)) ([78e2006](https://github.com/just-jeb/angular-builders/commit/78e200609bbdbc7d5d9bc76f5675283bdefc871b))
 
 ## [19.0.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@19.0.0-beta.0...@angular-builders/custom-esbuild@19.0.0) (2025-01-05)
 
@@ -235,17 +206,17 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** update to Angular 19 (#1871)
+- **deps:** update to Angular 19 (#1871)
 
 ### Miscellaneous Chores
 
-* **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
+- **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
 
 ## [18.1.0-beta.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@18.0.1-beta.0...@angular-builders/custom-esbuild@18.1.0-beta.0) (2024-11-11)
 
 ### Features
 
-* **custom-esbuild:** add support for plugin configuration ([#1683](https://github.com/just-jeb/angular-builders/issues/1683)) ([9fbd32b](https://github.com/just-jeb/angular-builders/commit/9fbd32b0cc279bd9b6eaac1625d25b0c5c78406b))
+- **custom-esbuild:** add support for plugin configuration ([#1683](https://github.com/just-jeb/angular-builders/issues/1683)) ([9fbd32b](https://github.com/just-jeb/angular-builders/commit/9fbd32b0cc279bd9b6eaac1625d25b0c5c78406b))
 
 ## [18.0.1-beta.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-esbuild@18.0.0...@angular-builders/custom-esbuild@18.0.1-beta.0) (2024-07-23)
 

--- a/packages/custom-webpack/CHANGELOG.md
+++ b/packages/custom-webpack/CHANGELOG.md
@@ -7,47 +7,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 22
-* TypeScript configs/plugins are now transpiled (no build-time
-type-checking). Run `tsc --noEmit` separately to type-check config files.
-
-* test(custom-webpack,custom-esbuild,jest): mock loadModule instead of faking config files
-
-The jiti-based loader loads modules outside Jest's module registry, so specs can no
-longer fake user config files via jest.mock(path, {virtual:true}). Mock common's
-loadModule instead (loading is covered by common's own load-module.spec). Also drops
-the obsolete ts-node register-once/warn assertions, which no longer apply.
-
-* build!: run merge-schemes.ts via jiti and remove ts-node entirely
-
-merge-schemes.ts was executed with ts-node at build time; run it with jiti's CLI
-instead (added as a root devDependency) and drop ts-node from custom-webpack and
-custom-esbuild. ts-node is no longer used anywhere in the repo.
-* ts-node is no longer a dependency of @angular-builders packages.
-
-* test(examples): drop ts-node and ts-node/esm NODE_OPTIONS workaround
-
-TypeScript configs/plugins now load via jiti through the builders, so the ESM apps
-no longer need TS_NODE_PROJECT/NODE_OPTIONS='--loader ts-node/esm', and no example
-needs ts-node. Verified by the ts-config / esm / json-import / bundler-resolution
-integration tests passing with ts-node absent.
-
-* docs: update AGENTS.md and READMEs for jiti loader
-
-Reflect the jiti-based loader: drop ts-node/tsconfig-paths references and the
-ESM NODE_OPTIONS workaround, document transpile-only loading + tsc --noEmit
-type-check guidance, and record the get-tsconfig alias-resolution rationale.
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) (#2264)
+- All packages now require Angular 22.
+- User TypeScript config/plugin modules now load via `jiti` instead of `ts-node`. Configs are transpiled rather than type-checked (run `tsc --noEmit` separately if you relied on build-time type-checking); `ts-node` and `tsconfig-paths` are no longer dependencies; and the `NODE_OPTIONS='--loader ts-node/esm'` workaround for ESM apps is no longer needed.
 
 ### Features
 
-* ng add / ng update schematics for jest, custom-esbuild, custom-webpack ([#2267](https://github.com/just-jeb/angular-builders/issues/2267)) ([062f423](https://github.com/just-jeb/angular-builders/commit/062f423cbe2f87d97017ef4801cf6afb209f9191)), closes [2191/#2212](https://github.com/2191/angular-builders/issues/2212) [#2260](https://github.com/just-jeb/angular-builders/issues/2260) [#2212](https://github.com/just-jeb/angular-builders/issues/2212) [#2260](https://github.com/just-jeb/angular-builders/issues/2260)
-* replace ts-node with jiti for loading TypeScript modules ([#2287](https://github.com/just-jeb/angular-builders/issues/2287)) ([0348e06](https://github.com/just-jeb/angular-builders/commit/0348e06df73f57e62a8803a20c8b7b66b664a5d0)), closes [#816](https://github.com/just-jeb/angular-builders/issues/816)
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
+- ng add / ng update schematics for jest, custom-esbuild, custom-webpack ([#2267](https://github.com/just-jeb/angular-builders/issues/2267)) ([062f423](https://github.com/just-jeb/angular-builders/commit/062f423cbe2f87d97017ef4801cf6afb209f9191)), closes [#22](https://github.com/just-jeb/angular-builders/issues/22)
+- replace ts-node with jiti for loading TypeScript modules ([#2287](https://github.com/just-jeb/angular-builders/issues/2287)) ([0348e06](https://github.com/just-jeb/angular-builders/commit/0348e06df73f57e62a8803a20c8b7b66b664a5d0)), closes [#816](https://github.com/just-jeb/angular-builders/issues/816)
+- upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
 
 ### Miscellaneous Chores
 
-* graduate Angular 22 from RC to GA ([daec882](https://github.com/just-jeb/angular-builders/commit/daec8828f1dcd34c989af6ae782a431b3f3205ee))
+- graduate Angular 22 from RC to GA ([daec882](https://github.com/just-jeb/angular-builders/commit/daec8828f1dcd34c989af6ae782a431b3f3205ee))
 
 ## [21.1.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-webpack@21.1.0-beta.13...@angular-builders/custom-webpack@21.1.0) (2026-06-08)
 
@@ -57,19 +28,19 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### Reverts
 
-* remove redundant TS2742 builder annotations ([#2275](https://github.com/just-jeb/angular-builders/issues/2275), [#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([#2279](https://github.com/just-jeb/angular-builders/issues/2279)) ([a2882e5](https://github.com/just-jeb/angular-builders/commit/a2882e511ae2fa44dc445dbc9e73882de70981b5))
+- remove redundant TS2742 builder annotations ([#2275](https://github.com/just-jeb/angular-builders/issues/2275), [#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([#2279](https://github.com/just-jeb/angular-builders/issues/2279)) ([a2882e5](https://github.com/just-jeb/angular-builders/commit/a2882e511ae2fa44dc445dbc9e73882de70981b5))
 
 ## [21.1.0-beta.12](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-webpack@21.1.0-beta.11...@angular-builders/custom-webpack@21.1.0-beta.12) (2026-06-04)
 
 ### Bug Fixes
 
-* **builders:** annotate builder default exports with Builder<T> to avoid TS2742 ([#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([7db3848](https://github.com/just-jeb/angular-builders/commit/7db3848c7c3bf8362904130cbab8c7711cdac4ed))
+- **builders:** annotate builder default exports with Builder<T> to avoid TS2742 ([#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([7db3848](https://github.com/just-jeb/angular-builders/commit/7db3848c7c3bf8362904130cbab8c7711cdac4ed))
 
 ## [21.1.0-beta.11](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-webpack@21.1.0-beta.10...@angular-builders/custom-webpack@21.1.0-beta.11) (2026-06-01)
 
 ### Bug Fixes
 
-* **common:** add resolveJsonModule to ts-node compilerOptions (fixes [#816](https://github.com/just-jeb/angular-builders/issues/816)) ([#2189](https://github.com/just-jeb/angular-builders/issues/2189)) ([6b16727](https://github.com/just-jeb/angular-builders/commit/6b16727b2c4c2298418484fe346b5db931764fbb))
+- **common:** add resolveJsonModule to ts-node compilerOptions (fixes [#816](https://github.com/just-jeb/angular-builders/issues/816)) ([#2189](https://github.com/just-jeb/angular-builders/issues/2189)) ([6b16727](https://github.com/just-jeb/angular-builders/commit/6b16727b2c4c2298418484fe346b5db931764fbb))
 
 ## [21.1.0-beta.10](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-webpack@21.1.0-beta.9...@angular-builders/custom-webpack@21.1.0-beta.10) (2026-05-09)
 
@@ -87,9 +58,9 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### Bug Fixes
 
-* **common:** remove moduleResolution override in ts-node register (fixes [#2025](https://github.com/just-jeb/angular-builders/issues/2025)) ([#2187](https://github.com/just-jeb/angular-builders/issues/2187)) ([a0daa6a](https://github.com/just-jeb/angular-builders/commit/a0daa6a9730c4f918667f5f9a99dc373a41c1382))
-* **custom-webpack:** preserve anonymous plain-object plugins during merge ([#2183](https://github.com/just-jeb/angular-builders/issues/2183)) ([c0336c2](https://github.com/just-jeb/angular-builders/commit/c0336c2d01fa90d632bc431fd3f45593fdaad17b)), closes [angular/angular-cli#16817](https://github.com/angular/angular-cli/issues/16817) [#1908](https://github.com/just-jeb/angular-builders/issues/1908) [#1908](https://github.com/just-jeb/angular-builders/issues/1908)
-* **deps:** add rxjs>=7 as peer dependency to custom-esbuild, custom-webpack, and jest (fixes [#1863](https://github.com/just-jeb/angular-builders/issues/1863)) ([#2188](https://github.com/just-jeb/angular-builders/issues/2188)) ([2e067f5](https://github.com/just-jeb/angular-builders/commit/2e067f51eb3efb65fbef7050b8a10c499a585f0a))
+- **common:** remove moduleResolution override in ts-node register (fixes [#2025](https://github.com/just-jeb/angular-builders/issues/2025)) ([#2187](https://github.com/just-jeb/angular-builders/issues/2187)) ([a0daa6a](https://github.com/just-jeb/angular-builders/commit/a0daa6a9730c4f918667f5f9a99dc373a41c1382))
+- **custom-webpack:** preserve anonymous plain-object plugins during merge ([#2183](https://github.com/just-jeb/angular-builders/issues/2183)) ([c0336c2](https://github.com/just-jeb/angular-builders/commit/c0336c2d01fa90d632bc431fd3f45593fdaad17b)), closes [angular/angular-cli#16817](https://github.com/angular/angular-cli/issues/16817) [#1908](https://github.com/just-jeb/angular-builders/issues/1908) [#1908](https://github.com/just-jeb/angular-builders/issues/1908)
+- **deps:** add rxjs>=7 as peer dependency to custom-esbuild, custom-webpack, and jest (fixes [#1863](https://github.com/just-jeb/angular-builders/issues/1863)) ([#2188](https://github.com/just-jeb/angular-builders/issues/2188)) ([2e067f5](https://github.com/just-jeb/angular-builders/commit/2e067f51eb3efb65fbef7050b8a10c499a585f0a))
 
 ## [21.1.0-beta.6](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-webpack@21.1.0-beta.5...@angular-builders/custom-webpack@21.1.0-beta.6) (2026-03-10)
 
@@ -117,11 +88,11 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ## 21.1.0-beta.0 (2026-01-18)
 
-* feat(ci): add Turborepo for affected detection (#1981) ([884098b](https://github.com/just-jeb/angular-builders/commit/884098b)), closes [#1981](https://github.com/just-jeb/angular-builders/issues/1981)
+- feat(ci): add Turborepo for affected detection (#1981) ([884098b](https://github.com/just-jeb/angular-builders/commit/884098b)), closes [#1981](https://github.com/just-jeb/angular-builders/issues/1981)
 
 ## <small>21.0.4-beta.0 (2026-01-16)</small>
 
-* ci: revamp CI/CD with parallel matrix jobs (#1980) ([8de5b74](https://github.com/just-jeb/angular-builders/commit/8de5b74)), closes [#1980](https://github.com/just-jeb/angular-builders/issues/1980)
+- ci: revamp CI/CD with parallel matrix jobs (#1980) ([8de5b74](https://github.com/just-jeb/angular-builders/commit/8de5b74)), closes [#1980](https://github.com/just-jeb/angular-builders/issues/1980)
 
 ## <small>21.0.3 (2026-01-14)</small>
 
@@ -133,8 +104,8 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ## <small>21.0.3-beta.0 (2026-01-14)</small>
 
-* ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
-* ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
+- ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
+- ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
 
 ## [21.0.2](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-webpack@21.0.1-beta.0...@angular-builders/custom-webpack@21.0.2) (2026-01-13)
 
@@ -156,21 +127,21 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 21
+- All packages now require Angular 21
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [21.0.0-beta.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-webpack@20.0.1-beta.1...@angular-builders/custom-webpack@21.0.0-beta.0) (2025-12-17)
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 21
+- All packages now require Angular 21
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [20.0.1-beta.1](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-webpack@20.0.1-beta.0...@angular-builders/custom-webpack@20.0.1-beta.1) (2025-11-13)
 
@@ -188,15 +159,15 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** upgrade to Angular 20
+- **deps:** upgrade to Angular 20
 
 ### Features
 
-* migrate to @angular/build ([db2fc68](https://github.com/just-jeb/angular-builders/commit/db2fc689cf58be44bcbee6a13e9729ec88138e1b))
+- migrate to @angular/build ([db2fc68](https://github.com/just-jeb/angular-builders/commit/db2fc689cf58be44bcbee6a13e9729ec88138e1b))
 
 ### Miscellaneous Chores
 
-* **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
+- **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
 
 ## [19.0.1](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-webpack@19.0.1-beta.1...@angular-builders/custom-webpack@19.0.1) (2025-04-07)
 
@@ -218,11 +189,11 @@ type-check guidance, and record the get-tsconfig alias-resolution rationale.
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** update to Angular 19 (#1871)
+- **deps:** update to Angular 19 (#1871)
 
 ### Miscellaneous Chores
 
-* **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
+- **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
 
 ## [18.0.1-beta.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/custom-webpack@18.0.0...@angular-builders/custom-webpack@18.0.1-beta.0) (2024-07-24)
 

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -7,67 +7,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 22
-* TypeScript configs/plugins are now transpiled (no build-time
-type-checking). Run `tsc --noEmit` separately to type-check config files.
-
-* test(custom-webpack,custom-esbuild,jest): mock loadModule instead of faking config files
-
-The jiti-based loader loads modules outside Jest's module registry, so specs can no
-longer fake user config files via jest.mock(path, {virtual:true}). Mock common's
-loadModule instead (loading is covered by common's own load-module.spec). Also drops
-the obsolete ts-node register-once/warn assertions, which no longer apply.
-
-* build!: run merge-schemes.ts via jiti and remove ts-node entirely
-
-merge-schemes.ts was executed with ts-node at build time; run it with jiti's CLI
-instead (added as a root devDependency) and drop ts-node from custom-webpack and
-custom-esbuild. ts-node is no longer used anywhere in the repo.
-* ts-node is no longer a dependency of @angular-builders packages.
-
-* test(examples): drop ts-node and ts-node/esm NODE_OPTIONS workaround
-
-TypeScript configs/plugins now load via jiti through the builders, so the ESM apps
-no longer need TS_NODE_PROJECT/NODE_OPTIONS='--loader ts-node/esm', and no example
-needs ts-node. Verified by the ts-config / esm / json-import / bundler-resolution
-integration tests passing with ts-node absent.
-
-* docs: update AGENTS.md and READMEs for jiti loader
-
-Reflect the jiti-based loader: drop ts-node/tsconfig-paths references and the
-ESM NODE_OPTIONS workaround, document transpile-only loading + tsc --noEmit
-type-check guidance, and record the get-tsconfig alias-resolution rationale.
-* **jest:** scope coverage output per-project in multi-project workspaces (fixes #1009) (#2212)
-* **jest:** isolatedModules now defaults to true. This disables
-cross-file TypeScript type checking during jest runs. Targeted for the
-next major version.
-
-* test(jest): replace config-shape assertions with behavioral integration test
-
-Remove isolatedModules:true assertions from the unit spec — they tested
-implementation details (object shape), not user-visible behavior. Replace
-with targeted assertions on tsconfig path resolution, which is the actual
-behavioral contract of the resolver.
-
-Add isolated-modules-default integration test entry that proves Angular
-component tests still pass end-to-end with isolatedModules:true active,
-providing the behavioral regression guard for #1899.
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) (#2264)
+- All packages now require Angular 22.
+- User TypeScript config/plugin modules now load via `jiti` instead of `ts-node`. Configs are transpiled rather than type-checked (run `tsc --noEmit` separately if you relied on build-time type-checking); `ts-node` and `tsconfig-paths` are no longer dependencies; and the `NODE_OPTIONS='--loader ts-node/esm'` workaround for ESM apps is no longer needed.
+- `isolatedModules` now defaults to `true` for faster compilation, which disables cross-file TypeScript type-checking during Jest runs. Set `isolatedModules: false` in your config to restore the previous behavior.
+- Coverage output is now scoped per project: `coverageDirectory` defaults to `<projectRoot>/coverage` instead of `./coverage`, so projects in a multi-project workspace no longer overwrite each other's reports.
 
 ### Features
 
-* ng add / ng update schematics for jest, custom-esbuild, custom-webpack ([#2267](https://github.com/just-jeb/angular-builders/issues/2267)) ([062f423](https://github.com/just-jeb/angular-builders/commit/062f423cbe2f87d97017ef4801cf6afb209f9191)), closes [2191/#2212](https://github.com/2191/angular-builders/issues/2212) [#2260](https://github.com/just-jeb/angular-builders/issues/2260) [#2212](https://github.com/just-jeb/angular-builders/issues/2212) [#2260](https://github.com/just-jeb/angular-builders/issues/2260)
-* replace ts-node with jiti for loading TypeScript modules ([#2287](https://github.com/just-jeb/angular-builders/issues/2287)) ([0348e06](https://github.com/just-jeb/angular-builders/commit/0348e06df73f57e62a8803a20c8b7b66b664a5d0)), closes [#816](https://github.com/just-jeb/angular-builders/issues/816)
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
+- ng add / ng update schematics for jest, custom-esbuild, custom-webpack ([#2267](https://github.com/just-jeb/angular-builders/issues/2267)) ([062f423](https://github.com/just-jeb/angular-builders/commit/062f423cbe2f87d97017ef4801cf6afb209f9191)), closes [#22](https://github.com/just-jeb/angular-builders/issues/22)
+- replace ts-node with jiti for loading TypeScript modules ([#2287](https://github.com/just-jeb/angular-builders/issues/2287)) ([0348e06](https://github.com/just-jeb/angular-builders/commit/0348e06df73f57e62a8803a20c8b7b66b664a5d0)), closes [#816](https://github.com/just-jeb/angular-builders/issues/816)
+- upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
 
 ### Bug Fixes
 
-* **jest:** default isolatedModules to true for faster compilation (fixes [#1899](https://github.com/just-jeb/angular-builders/issues/1899)) ([#2191](https://github.com/just-jeb/angular-builders/issues/2191)) ([acd2d37](https://github.com/just-jeb/angular-builders/commit/acd2d3702a4a970dd18c5b8a82214fbaed856a8e))
-* **jest:** scope coverage output per-project in multi-project workspaces (fixes [#1009](https://github.com/just-jeb/angular-builders/issues/1009)) ([#2212](https://github.com/just-jeb/angular-builders/issues/2212)) ([0ac5d6d](https://github.com/just-jeb/angular-builders/commit/0ac5d6db008f441567d7485867cda56aaa00bebc))
+- **jest:** default isolatedModules to true for faster compilation (fixes [#1899](https://github.com/just-jeb/angular-builders/issues/1899)) ([#2191](https://github.com/just-jeb/angular-builders/issues/2191)) ([acd2d37](https://github.com/just-jeb/angular-builders/commit/acd2d3702a4a970dd18c5b8a82214fbaed856a8e))
+- **jest:** scope coverage output per-project in multi-project workspaces (fixes [#1009](https://github.com/just-jeb/angular-builders/issues/1009)) ([#2212](https://github.com/just-jeb/angular-builders/issues/2212)) ([0ac5d6d](https://github.com/just-jeb/angular-builders/commit/0ac5d6db008f441567d7485867cda56aaa00bebc))
 
 ### Miscellaneous Chores
 
-* graduate Angular 22 from RC to GA ([daec882](https://github.com/just-jeb/angular-builders/commit/daec8828f1dcd34c989af6ae782a431b3f3205ee))
+- graduate Angular 22 from RC to GA ([daec882](https://github.com/just-jeb/angular-builders/commit/daec8828f1dcd34c989af6ae782a431b3f3205ee))
 
 ## [21.0.4](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@21.0.4-beta.17...@angular-builders/jest@21.0.4) (2026-06-08)
 
@@ -81,25 +39,25 @@ providing the behavioral regression guard for #1899.
 
 ### Reverts
 
-* remove redundant TS2742 builder annotations ([#2275](https://github.com/just-jeb/angular-builders/issues/2275), [#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([#2279](https://github.com/just-jeb/angular-builders/issues/2279)) ([a2882e5](https://github.com/just-jeb/angular-builders/commit/a2882e511ae2fa44dc445dbc9e73882de70981b5))
+- remove redundant TS2742 builder annotations ([#2275](https://github.com/just-jeb/angular-builders/issues/2275), [#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([#2279](https://github.com/just-jeb/angular-builders/issues/2279)) ([a2882e5](https://github.com/just-jeb/angular-builders/commit/a2882e511ae2fa44dc445dbc9e73882de70981b5))
 
 ## [21.0.4-beta.15](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@21.0.4-beta.14...@angular-builders/jest@21.0.4-beta.15) (2026-06-04)
 
 ### Bug Fixes
 
-* **builders:** annotate builder default exports with Builder<T> to avoid TS2742 ([#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([7db3848](https://github.com/just-jeb/angular-builders/commit/7db3848c7c3bf8362904130cbab8c7711cdac4ed))
+- **builders:** annotate builder default exports with Builder<T> to avoid TS2742 ([#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([7db3848](https://github.com/just-jeb/angular-builders/commit/7db3848c7c3bf8362904130cbab8c7711cdac4ed))
 
 ## [21.0.4-beta.14](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@21.0.4-beta.13...@angular-builders/jest@21.0.4-beta.14) (2026-06-01)
 
 ### Bug Fixes
 
-* **jest:** suppress warning when jest config is provided inline in angular.json (fixes [#1102](https://github.com/just-jeb/angular-builders/issues/1102)) ([#2213](https://github.com/just-jeb/angular-builders/issues/2213)) ([6e7c93f](https://github.com/just-jeb/angular-builders/commit/6e7c93f2e9a02ff4dafdbb0544fb0da7ace6afb2))
+- **jest:** suppress warning when jest config is provided inline in angular.json (fixes [#1102](https://github.com/just-jeb/angular-builders/issues/1102)) ([#2213](https://github.com/just-jeb/angular-builders/issues/2213)) ([6e7c93f](https://github.com/just-jeb/angular-builders/commit/6e7c93f2e9a02ff4dafdbb0544fb0da7ace6afb2))
 
 ## [21.0.4-beta.13](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@21.0.4-beta.12...@angular-builders/jest@21.0.4-beta.13) (2026-06-01)
 
 ### Bug Fixes
 
-* **jest:** emit --findRelatedTests with positional file args (fixes [#2150](https://github.com/just-jeb/angular-builders/issues/2150), [#1859](https://github.com/just-jeb/angular-builders/issues/1859)) ([#2237](https://github.com/just-jeb/angular-builders/issues/2237)) ([47f3b67](https://github.com/just-jeb/angular-builders/commit/47f3b67e2ee487f4c8d9019f1cd83dbf2e0c7284))
+- **jest:** emit --findRelatedTests with positional file args (fixes [#2150](https://github.com/just-jeb/angular-builders/issues/2150), [#1859](https://github.com/just-jeb/angular-builders/issues/1859)) ([#2237](https://github.com/just-jeb/angular-builders/issues/2237)) ([47f3b67](https://github.com/just-jeb/angular-builders/commit/47f3b67e2ee487f4c8d9019f1cd83dbf2e0c7284))
 
 ## [21.0.4-beta.12](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@21.0.4-beta.11...@angular-builders/jest@21.0.4-beta.12) (2026-06-01)
 
@@ -121,7 +79,7 @@ providing the behavioral regression guard for #1899.
 
 ### Bug Fixes
 
-* **deps:** add rxjs>=7 as peer dependency to custom-esbuild, custom-webpack, and jest (fixes [#1863](https://github.com/just-jeb/angular-builders/issues/1863)) ([#2188](https://github.com/just-jeb/angular-builders/issues/2188)) ([2e067f5](https://github.com/just-jeb/angular-builders/commit/2e067f51eb3efb65fbef7050b8a10c499a585f0a))
+- **deps:** add rxjs>=7 as peer dependency to custom-esbuild, custom-webpack, and jest (fixes [#1863](https://github.com/just-jeb/angular-builders/issues/1863)) ([#2188](https://github.com/just-jeb/angular-builders/issues/2188)) ([2e067f5](https://github.com/just-jeb/angular-builders/commit/2e067f51eb3efb65fbef7050b8a10c499a585f0a))
 
 ## [21.0.4-beta.7](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@21.0.4-beta.6...@angular-builders/jest@21.0.4-beta.7) (2026-03-10)
 
@@ -151,11 +109,11 @@ providing the behavioral regression guard for #1899.
 
 ### Bug Fixes
 
-* **jest:** matchMedia mock survives resetMocks option ([#1999](https://github.com/just-jeb/angular-builders/issues/1999)) ([7f2e4b4](https://github.com/just-jeb/angular-builders/commit/7f2e4b411a2d9e5b1702808124bd205ca5d676c2)), closes [#1983](https://github.com/just-jeb/angular-builders/issues/1983)
+- **jest:** matchMedia mock survives resetMocks option ([#1999](https://github.com/just-jeb/angular-builders/issues/1999)) ([7f2e4b4](https://github.com/just-jeb/angular-builders/commit/7f2e4b411a2d9e5b1702808124bd205ca5d676c2)), closes [#1983](https://github.com/just-jeb/angular-builders/issues/1983)
 
 ## <small>21.0.4-beta.0 (2026-01-16)</small>
 
-* ci: revamp CI/CD with parallel matrix jobs (#1980) ([8de5b74](https://github.com/just-jeb/angular-builders/commit/8de5b74)), closes [#1980](https://github.com/just-jeb/angular-builders/issues/1980)
+- ci: revamp CI/CD with parallel matrix jobs (#1980) ([8de5b74](https://github.com/just-jeb/angular-builders/commit/8de5b74)), closes [#1980](https://github.com/just-jeb/angular-builders/issues/1980)
 
 ## <small>21.0.3 (2026-01-14)</small>
 
@@ -167,8 +125,8 @@ providing the behavioral regression guard for #1899.
 
 ## <small>21.0.3-beta.0 (2026-01-14)</small>
 
-* ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
-* ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
+- ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
+- ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
 
 ## [21.0.2](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@21.0.1-beta.0...@angular-builders/jest@21.0.2) (2026-01-13)
 
@@ -190,12 +148,14 @@ providing the behavioral regression guard for #1899.
 
 ### ⚠ BREAKING CHANGES
 
-* **jest:** configPath option renamed to config
+- **jest:** configPath option renamed to config
 
 The config option now accepts:
+
 - File path (string): "jest.config.js"
 - JSON string: '{"verbose": true}'
 - Inline object in angular.json
+
 * **jest:** zoneless is now the default
 
 Apps using zone.js change detection must set zoneless: false in angular.json.
@@ -203,45 +163,50 @@ Apps using zone.js change detection must set zoneless: false in angular.json.
 globalMocks option now only supports matchMedia. The styleTransform,
 getComputedStyle, and doctype mocks have been removed as Jest 30's
 jsdom supports these natively.
-* **jest:** Requires Jest 30
+
+- **jest:** Requires Jest 30
 
 Users must upgrade:
 npm install --save-dev jest@^30.0.0 jest-environment-jsdom@^30.0.0 jsdom@^26.0.0
 
 Also requires tsconfig.spec.json update for moduleResolution compatibility:
 {
-  "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "isolatedModules": true
-  }
+"compilerOptions": {
+"module": "Node16",
+"moduleResolution": "Node16",
+"isolatedModules": true
+}
 }
 
 Schema changes:
+
 - testPathPattern renamed to testPathPatterns
 - Removed: browser, init, mapCoverage, testURL, timers
+
 * All packages now require Angular 21
 
 ### Features
 
-* **jest:** add zoneless testing support ([1f23ca4](https://github.com/just-jeb/angular-builders/commit/1f23ca453017c40d4b78a9383eb8ccd19959a234)), closes [#1934](https://github.com/just-jeb/angular-builders/issues/1934)
-* **jest:** rename configPath to config with object support ([7bfe312](https://github.com/just-jeb/angular-builders/commit/7bfe31233d86cd04798055d19a552e7d8ab424a3)), closes [#108](https://github.com/just-jeb/angular-builders/issues/108)
-* **jest:** upgrade to Jest 30 via jest-preset-angular v16 ([ca4b6d9](https://github.com/just-jeb/angular-builders/commit/ca4b6d91372ff0bc2c827135a9f3ce2b4bc3e0f9)), closes [#1931](https://github.com/just-jeb/angular-builders/issues/1931)
+- **jest:** add zoneless testing support ([1f23ca4](https://github.com/just-jeb/angular-builders/commit/1f23ca453017c40d4b78a9383eb8ccd19959a234)), closes [#1934](https://github.com/just-jeb/angular-builders/issues/1934)
+- **jest:** rename configPath to config with object support ([7bfe312](https://github.com/just-jeb/angular-builders/commit/7bfe31233d86cd04798055d19a552e7d8ab424a3)), closes [#108](https://github.com/just-jeb/angular-builders/issues/108)
+- **jest:** upgrade to Jest 30 via jest-preset-angular v16 ([ca4b6d9](https://github.com/just-jeb/angular-builders/commit/ca4b6d91372ff0bc2c827135a9f3ce2b4bc3e0f9)), closes [#1931](https://github.com/just-jeb/angular-builders/issues/1931)
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [21.0.0-beta.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@20.0.1-beta.1...@angular-builders/jest@21.0.0-beta.0) (2025-12-17)
 
 ### ⚠ BREAKING CHANGES
 
-* **jest:** configPath option renamed to config
+- **jest:** configPath option renamed to config
 
 The config option now accepts:
+
 - File path (string): "jest.config.js"
 - JSON string: '{"verbose": true}'
 - Inline object in angular.json
+
 * **jest:** zoneless is now the default
 
 Apps using zone.js change detection must set zoneless: false in angular.json.
@@ -249,34 +214,37 @@ Apps using zone.js change detection must set zoneless: false in angular.json.
 globalMocks option now only supports matchMedia. The styleTransform,
 getComputedStyle, and doctype mocks have been removed as Jest 30's
 jsdom supports these natively.
-* **jest:** Requires Jest 30
+
+- **jest:** Requires Jest 30
 
 Users must upgrade:
 npm install --save-dev jest@^30.0.0 jest-environment-jsdom@^30.0.0 jsdom@^26.0.0
 
 Also requires tsconfig.spec.json update for moduleResolution compatibility:
 {
-  "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "isolatedModules": true
-  }
+"compilerOptions": {
+"module": "Node16",
+"moduleResolution": "Node16",
+"isolatedModules": true
+}
 }
 
 Schema changes:
+
 - testPathPattern renamed to testPathPatterns
 - Removed: browser, init, mapCoverage, testURL, timers
+
 * All packages now require Angular 21
 
 ### Features
 
-* **jest:** add zoneless testing support ([1f23ca4](https://github.com/just-jeb/angular-builders/commit/1f23ca453017c40d4b78a9383eb8ccd19959a234)), closes [#1934](https://github.com/just-jeb/angular-builders/issues/1934)
-* **jest:** rename configPath to config with object support ([7bfe312](https://github.com/just-jeb/angular-builders/commit/7bfe31233d86cd04798055d19a552e7d8ab424a3)), closes [#108](https://github.com/just-jeb/angular-builders/issues/108)
-* **jest:** upgrade to Jest 30 via jest-preset-angular v16 ([ca4b6d9](https://github.com/just-jeb/angular-builders/commit/ca4b6d91372ff0bc2c827135a9f3ce2b4bc3e0f9)), closes [#1931](https://github.com/just-jeb/angular-builders/issues/1931)
+- **jest:** add zoneless testing support ([1f23ca4](https://github.com/just-jeb/angular-builders/commit/1f23ca453017c40d4b78a9383eb8ccd19959a234)), closes [#1934](https://github.com/just-jeb/angular-builders/issues/1934)
+- **jest:** rename configPath to config with object support ([7bfe312](https://github.com/just-jeb/angular-builders/commit/7bfe31233d86cd04798055d19a552e7d8ab424a3)), closes [#108](https://github.com/just-jeb/angular-builders/issues/108)
+- **jest:** upgrade to Jest 30 via jest-preset-angular v16 ([ca4b6d9](https://github.com/just-jeb/angular-builders/commit/ca4b6d91372ff0bc2c827135a9f3ce2b4bc3e0f9)), closes [#1931](https://github.com/just-jeb/angular-builders/issues/1931)
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [20.0.1-beta.1](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@20.0.1-beta.0...@angular-builders/jest@20.0.1-beta.1) (2025-11-13)
 
@@ -294,15 +262,15 @@ Schema changes:
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** upgrade to Angular 20
+- **deps:** upgrade to Angular 20
 
 ### Features
 
-* migrate to @angular/build ([db2fc68](https://github.com/just-jeb/angular-builders/commit/db2fc689cf58be44bcbee6a13e9729ec88138e1b))
+- migrate to @angular/build ([db2fc68](https://github.com/just-jeb/angular-builders/commit/db2fc689cf58be44bcbee6a13e9729ec88138e1b))
 
 ### Miscellaneous Chores
 
-* **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
+- **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
 
 ## [19.0.1](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@19.0.1-beta.1...@angular-builders/jest@19.0.1) (2025-04-07)
 
@@ -328,11 +296,11 @@ Schema changes:
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** update to Angular 19 (#1871)
+- **deps:** update to Angular 19 (#1871)
 
 ### Miscellaneous Chores
 
-* **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
+- **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
 
 ## [18.0.1-beta.2](https://github.com/just-jeb/angular-builders/compare/@angular-builders/jest@18.0.1-beta.1...@angular-builders/jest@18.0.1-beta.2) (2024-10-30)
 

--- a/packages/timestamp/CHANGELOG.md
+++ b/packages/timestamp/CHANGELOG.md
@@ -7,11 +7,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) (#2264)
+- All packages now require Angular 22.
 
 ### Features
 
-* upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
+- upgrade builders + examples to Angular 22 (22.0.0-rc.2) ([#2264](https://github.com/just-jeb/angular-builders/issues/2264)) ([9ed7020](https://github.com/just-jeb/angular-builders/commit/9ed7020edc14b706fb3bbcbf811ac8ad3ea7e132))
 
 ## [21.0.4](https://github.com/just-jeb/angular-builders/compare/@angular-builders/timestamp@21.0.4-beta.10...@angular-builders/timestamp@21.0.4) (2026-06-08)
 
@@ -21,13 +21,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Reverts
 
-* remove redundant TS2742 builder annotations ([#2275](https://github.com/just-jeb/angular-builders/issues/2275), [#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([#2279](https://github.com/just-jeb/angular-builders/issues/2279)) ([a2882e5](https://github.com/just-jeb/angular-builders/commit/a2882e511ae2fa44dc445dbc9e73882de70981b5))
+- remove redundant TS2742 builder annotations ([#2275](https://github.com/just-jeb/angular-builders/issues/2275), [#2278](https://github.com/just-jeb/angular-builders/issues/2278)) ([#2279](https://github.com/just-jeb/angular-builders/issues/2279)) ([a2882e5](https://github.com/just-jeb/angular-builders/commit/a2882e511ae2fa44dc445dbc9e73882de70981b5))
 
 ## [21.0.4-beta.9](https://github.com/just-jeb/angular-builders/compare/@angular-builders/timestamp@21.0.4-beta.8...@angular-builders/timestamp@21.0.4-beta.9) (2026-06-04)
 
 ### Bug Fixes
 
-* **timestamp:** annotate default export with Builder<T> to avoid TS2742 ([#2275](https://github.com/just-jeb/angular-builders/issues/2275)) ([e32a3a1](https://github.com/just-jeb/angular-builders/commit/e32a3a198fd946c1867c21375246d7cb6ac1a568))
+- **timestamp:** annotate default export with Builder<T> to avoid TS2742 ([#2275](https://github.com/just-jeb/angular-builders/issues/2275)) ([e32a3a1](https://github.com/just-jeb/angular-builders/commit/e32a3a198fd946c1867c21375246d7cb6ac1a568))
 
 ## [21.0.4-beta.8](https://github.com/just-jeb/angular-builders/compare/@angular-builders/timestamp@21.0.4-beta.7...@angular-builders/timestamp@21.0.4-beta.8) (2026-05-09)
 
@@ -71,8 +71,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## <small>21.0.3-beta.0 (2026-01-14)</small>
 
-* ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
-* ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
+- ci(release): publish ([9c0d187](https://github.com/just-jeb/angular-builders/commit/9c0d187))
+- ci(release): publish ([5d8e5f7](https://github.com/just-jeb/angular-builders/commit/5d8e5f7))
 
 ## [21.0.2](https://github.com/just-jeb/angular-builders/compare/@angular-builders/timestamp@21.0.1-beta.0...@angular-builders/timestamp@21.0.2) (2026-01-13)
 
@@ -94,21 +94,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 21
+- All packages now require Angular 21
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [21.0.0-beta.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/timestamp@20.1.0-beta.1...@angular-builders/timestamp@21.0.0-beta.0) (2025-12-17)
 
 ### ⚠ BREAKING CHANGES
 
-* All packages now require Angular 21
+- All packages now require Angular 21
 
 ### Miscellaneous Chores
 
-* upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
+- upgrade to Angular 21 ([98059dc](https://github.com/just-jeb/angular-builders/commit/98059dcfc2c2654f4672cb6f4597835522ee50ba)), closes [#1957](https://github.com/just-jeb/angular-builders/issues/1957)
 
 ## [20.1.0-beta.1](https://github.com/just-jeb/angular-builders/compare/@angular-builders/timestamp@20.1.0-beta.0...@angular-builders/timestamp@20.1.0-beta.1) (2025-11-13)
 
@@ -118,7 +118,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **custom-esbuild:** add `unit-test` builder ([#1935](https://github.com/just-jeb/angular-builders/issues/1935)) ([00972a8](https://github.com/just-jeb/angular-builders/commit/00972a880d4747c521d4aa5f03b7268ec0b43e29))
+- **custom-esbuild:** add `unit-test` builder ([#1935](https://github.com/just-jeb/angular-builders/issues/1935)) ([00972a8](https://github.com/just-jeb/angular-builders/commit/00972a880d4747c521d4aa5f03b7268ec0b43e29))
 
 ## [20.0.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/timestamp@20.0.0-beta.0...@angular-builders/timestamp@20.0.0) (2025-06-25)
 
@@ -128,11 +128,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** upgrade to Angular 20
+- **deps:** upgrade to Angular 20
 
 ### Miscellaneous Chores
 
-* **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
+- **deps:** upgrade to Angular 20 ([4f673a8](https://github.com/just-jeb/angular-builders/commit/4f673a8ae090c226b67c4e249a161a968e1964da))
 
 ## [19.0.1](https://github.com/just-jeb/angular-builders/compare/@angular-builders/timestamp@19.0.1-beta.0...@angular-builders/timestamp@19.0.1) (2025-04-07)
 
@@ -150,11 +150,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* **deps:** update to Angular 19 (#1871)
+- **deps:** update to Angular 19 (#1871)
 
 ### Miscellaneous Chores
 
-* **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
+- **deps:** update to Angular 19 ([#1871](https://github.com/just-jeb/angular-builders/issues/1871)) ([d3b17ed](https://github.com/just-jeb/angular-builders/commit/d3b17ed1e520c299f0327b9b5c38a55494b0a19a))
 
 ## [18.0.0](https://github.com/just-jeb/angular-builders/compare/@angular-builders/timestamp@18.0.0-beta.3...@angular-builders/timestamp@18.0.0) (2024-06-17)
 


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added — N/A (changelog content only)
- [x] Docs have been added / updated

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update
[ ] Refactoring
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
```

## What is the current behavior?

The `22.0.0-beta.0` / `6.0.0-beta.0` CHANGELOG sections were generated from the verbose **squash-commit bodies** of #2287 (jiti) and #2191 (jest). conventional-changelog pulled the internal sub-commit messages (`test(...)`, `build!`, `docs:` paragraphs) into the **BREAKING CHANGES** lists, burying the actual user-facing breaking changes. The schematics Features line also had a garbled `closes` link pointing at a broken `github.com/2191/...` URL.

## What is the new behavior?

Each affected package's `22.0.0-beta.0` (common `6.0.0-beta.0`) **BREAKING CHANGES** section now states the real breaking changes only:
- All packages require Angular 22
- jiti loader replaces ts-node (transpile-only; `ts-node`/`tsconfig-paths` removed; `NODE_OPTIONS` workaround gone)
- jest `isolatedModules` defaults to `true`
- jest coverage scoped per-project

Garbled schematics `closes` link fixed to `#22`. Historical (v21 and earlier) sections untouched.

Manual edit of generated CHANGELOGs is intentional (the generator carried CI/squash noise that doesn't represent reality). `docs` is a hidden changelog type, so this PR adds no new entry and triggers no version bump.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Cleans up the noise that landed in the v22 beta CHANGELOGs before graduation.
