### PR TITLE
fix(ci): install Cypress binary in build job to populate cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
           path: |
             node_modules
             .yarn
-            ~/.cache/Cypress
           key: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           restore-keys: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-
       - uses: actions/cache@v5
@@ -62,17 +61,25 @@ jobs:
           path: ~/.cache
           key: yarn-dl-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-dl-${{ runner.os }}-
+      # The Cypress binary (~/.cache/Cypress/<version>) is cached separately from node_modules,
+      # NOT folded into the deps cache. Reason: the deps cache uses actions/cache (save-on-miss)
+      # keyed by yarn.lock; once it holds a binary, an exact key hit never re-saves, so a stale
+      # binary "snowballs" — a Cypress version bump can't replace it and integration jobs fail
+      # with "the Cypress binary is missing" for the new version. (This is how #2293's bump
+      # broke master.) Keying this cache by yarn.lock means a bump forces a fresh save; the
+      # `cypress install` step below downloads the resolved version into it. restore-keys lets
+      # an unrelated lockfile change reuse the previous binary so install no-ops.
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: cypress-${{ runner.os }}-
       - run: yarn --immutable
-      # Cypress downloads its binary to ~/.cache/Cypress via a postinstall script, but that
-      # script is skipped when yarn restores build-state from a prior cache (restore-keys
-      # serves the previous yarn.lock's cache on any dep change). The binary then never
-      # re-downloads on a Cypress version bump, so integration jobs fail with "the Cypress
-      # binary is missing" for the new version. `cypress install` downloads the binary for the
-      # resolved version and is a no-op if already present, guaranteeing the saved cache holds
-      # the matching binary regardless of restore-key fallback. See #2293 (bump merged with no
-      # e2e run) and https://docs.cypress.io/app/continuous-integration/overview.
-      # Invoke the hoisted binary directly: in Yarn Berry `yarn cypress` resolves to a script
-      # name, and Cypress is a workspace (example) dependency, not a root one.
+      # Populate the Cypress cache above with the resolved version's binary (idempotent — a
+      # no-op if already present). yarn's own postinstall skips this when build-state is
+      # restored from cache, so do it explicitly. Invoke the hoisted binary directly: in Yarn
+      # Berry `yarn cypress` resolves to a script name, and Cypress is a workspace (example)
+      # dependency, not a root one.
       - run: node_modules/.bin/cypress install
       # On PRs, build only affected packages unless 'ci:full' label is present.
       # On master events (push/workflow_dispatch), build all packages. (see #2026)
@@ -117,9 +124,15 @@ jobs:
           path: |
             node_modules
             .yarn
-            ~/.cache/Cypress
           key: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
+      # Restore the Cypress binary saved by the build job (same key). e2e tests (yarn e2e)
+      # launch Cypress, which needs its binary present in ~/.cache/Cypress.
+      - uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: cypress-${{ runner.os }}-
       - uses: actions/download-artifact@v8
         with:
           name: dist
@@ -162,7 +175,6 @@ jobs:
           path: |
             node_modules
             .yarn
-            ~/.cache/Cypress
           key: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
       - uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,15 @@ jobs:
           key: yarn-dl-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-dl-${{ runner.os }}-
       - run: yarn --immutable
+      # Cypress downloads its binary to ~/.cache/Cypress via a postinstall script, but that
+      # script is skipped when yarn restores build-state from a prior cache (restore-keys
+      # serves the previous yarn.lock's cache on any dep change). The binary then never
+      # re-downloads on a Cypress version bump, so integration jobs fail with "the Cypress
+      # binary is missing" for the new version. `cypress install` downloads the binary for the
+      # resolved version and is a no-op if already present, guaranteeing the saved cache holds
+      # the matching binary regardless of restore-key fallback. See #2293 (bump merged with no
+      # e2e run) and https://docs.cypress.io/app/continuous-integration/overview.
+      - run: yarn cypress install
       # On PRs, build only affected packages unless 'ci:full' label is present.
       # On master events (push/workflow_dispatch), build all packages. (see #2026)
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
       # resolved version and is a no-op if already present, guaranteeing the saved cache holds
       # the matching binary regardless of restore-key fallback. See #2293 (bump merged with no
       # e2e run) and https://docs.cypress.io/app/continuous-integration/overview.
-      - run: yarn cypress install
+      # Invoke the hoisted binary directly: in Yarn Berry `yarn cypress` resolves to a script
+      # name, and Cypress is a workspace (example) dependency, not a root one.
+      - run: node_modules/.bin/cypress install
       # On PRs, build only affected packages unless 'ci:full' label is present.
       # On master events (push/workflow_dispatch), build all packages. (see #2026)
       - run: |


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features) — N/A, CI infrastructure fix; the existing Cypress integration matrix is the test and is currently red on master
- [ ] Docs have been added / updated (for bug fixes / features) — N/A

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`master` and several open Renovate PRs (#2296, #2297, #2301) fail the `custom-esbuild`, `custom-webpack`, and `jest` e2e integration jobs with:

```
The cypress npm package is installed, but the Cypress binary is missing.
We expected the binary to be installed here: /home/runner/.cache/Cypress/15.17.0/Cypress/Cypress
```

Root cause: the Cypress binary in `~/.cache/Cypress/<version>/` is downloaded by Cypress's postinstall during `yarn install`. The dep cache uses lax `restore-keys`, so any `yarn.lock` change falls back to the previous lockfile's cache — which also restores yarn's build-state. The restored build-state marks Cypress as already built, so the postinstall is skipped and the binary for the new version is never downloaded. The build job then saves a cache that only contains the old version's binary, and integration jobs can't find the binary for the resolved version.

This was latent until #2293 bumped Cypress `15.16.0 → 15.17.0`. That PR changed only `examples/**` + `yarn.lock`, so Turbo's affected-package filter found no builder package and `has_tests=false` — the integration matrix was skipped and the bump merged without a single e2e test running. The first subsequent push that touched a builder package surfaced the break.

## What is the new behavior?

An idempotent `yarn cypress install` runs in the build job right after `yarn --immutable`. It downloads the binary for the currently-resolved Cypress version (no-op if already present), so the saved dependency cache always contains the matching binary regardless of restore-key fallback. Unblocks master and the affected Renovate PRs.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Cypress documents this exact failure mode for CI caching: https://docs.cypress.io/app/continuous-integration/overview

A follow-up could isolate `~/.cache/Cypress` into its own cache keyed by the Cypress version (instead of riding the lax dep cache), which removes the stale-binary "snowball" at the source. This PR is the minimal fix to get CI green now.
