### PR TITLE
fix(ci): group Angular and Angular CLI Renovate updates into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,11 @@
       "matchPackageNames": ["@angular-devkit/architect"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Angular framework (@angular/*) and Angular CLI (@angular/cli + @angular-devkit/*) ship on the same version train and must move together. Renovate's monorepo presets put them in two separate groups, so one can merge ahead of the other — that leaves @angular-devkit/core resolved at two versions at once, its Logger class gets two distinct identities, and custom-esbuild fails to compile ('_subject is protected but type Logger is not a class derived from Logger'). This is what broke the standalone angular-cli-monorepo patch bump in #2299. Group both scopes into one PR so the whole Angular tree always bumps atomically. (The architect major-hold above still applies — majors remain a deliberate manual step via the update workflow.)",
+      "groupName": "angular",
+      "matchPackageNames": ["@angular/**", "@angular-devkit/**"]
     }
   ]
 }


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features) — N/A, Renovate config; not unit-testable in this repo
- [ ] Docs have been added / updated (for bug fixes / features) — N/A (rule is self-documented inline)

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe: dependency-automation (Renovate) config
```

## What is the current behavior?

Renovate's monorepo preset treats the Angular framework (`@angular/*`, including `@angular/build`) and the Angular CLI (`@angular/cli` + `@angular-devkit/*`) as **two separate update groups**, even though they release on the same version train. When one group's PR merges before the other, the dep tree ends up with `@angular-devkit/core` resolved at **two versions at once**.

`@angular-devkit/core`'s `Logger` class has a `protected _subject`. With two copies present, the `Logger` returned by `logger.createChild()` (one copy) is structurally incompatible with the `Logger` that `@angular/build`'s `buildApplication`/`executeDevServerBuilder` expect (the other copy), so `custom-esbuild` fails to compile:

```
Property '_subject' is protected but type 'Logger' is not a class derived from 'Logger'.
```

This is exactly how the standalone `angular-cli-monorepo` → 22.0.1 patch bump (#2299) broke the build while `master` (single `@angular-devkit/core` at 22.0.0) stayed green. Verified by comparing resolved versions:

| | `@angular-devkit/core` | `@angular/build` | `@angular-devkit/architect` |
|---|---|---|---|
| master (compiles) | 22.0.0 only | 22.0.0 only | 0.2200.0 only |
| #2299 (fails) | **22.0.0 + 22.0.1** | **22.0.0 + 22.0.1** | **0.2200.0 + 0.2200.1** |

## What is the new behavior?

A `packageRule` with a shared `groupName: "angular"` matching `@angular/**` and `@angular-devkit/**`, so the entire Angular ecosystem always bumps in a **single atomic PR**. The tree can no longer be left with two `@angular-devkit/core` versions across a routine patch/minor update.

The existing `@angular-devkit/architect` major-hold is untouched — Angular **major** bumps remain a deliberate manual step via the update workflow (#2263 policy). This rule targets the routine patch/minor skew that #2299 hit.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

- Resolves the root cause behind #2299; #2299 itself should be closed/superseded and re-raised as a grouped Angular update once this lands.
- Optional follow-up: set `automerge: false` for the `angular` group so grouped Angular updates always get a manual review (Angular upgrades are the most common source of user-reported compat issues). Left out here to keep the change minimal.
