### PR TITLE
test: cypress cache snowball validation (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
           path: |
             node_modules
             .yarn
-            ~/.cache/Cypress
           key: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           restore-keys: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-
       - uses: actions/cache@v5
@@ -62,17 +61,25 @@ jobs:
           path: ~/.cache
           key: yarn-dl-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-dl-${{ runner.os }}-
+      # The Cypress binary (~/.cache/Cypress/<version>) is cached separately from node_modules,
+      # NOT folded into the deps cache. Reason: the deps cache uses actions/cache (save-on-miss)
+      # keyed by yarn.lock; once it holds a binary, an exact key hit never re-saves, so a stale
+      # binary "snowballs" — a Cypress version bump can't replace it and integration jobs fail
+      # with "the Cypress binary is missing" for the new version. (This is how #2293's bump
+      # broke master.) Keying this cache by yarn.lock means a bump forces a fresh save; the
+      # `cypress install` step below downloads the resolved version into it. restore-keys lets
+      # an unrelated lockfile change reuse the previous binary so install no-ops.
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: cypress-${{ runner.os }}-
       - run: yarn --immutable
-      # Cypress downloads its binary to ~/.cache/Cypress via a postinstall script, but that
-      # script is skipped when yarn restores build-state from a prior cache (restore-keys
-      # serves the previous yarn.lock's cache on any dep change). The binary then never
-      # re-downloads on a Cypress version bump, so integration jobs fail with "the Cypress
-      # binary is missing" for the new version. `cypress install` downloads the binary for the
-      # resolved version and is a no-op if already present, guaranteeing the saved cache holds
-      # the matching binary regardless of restore-key fallback. See #2293 (bump merged with no
-      # e2e run) and https://docs.cypress.io/app/continuous-integration/overview.
-      # Invoke the hoisted binary directly: in Yarn Berry `yarn cypress` resolves to a script
-      # name, and Cypress is a workspace (example) dependency, not a root one.
+      # Populate the Cypress cache above with the resolved version's binary (idempotent — a
+      # no-op if already present). yarn's own postinstall skips this when build-state is
+      # restored from cache, so do it explicitly. Invoke the hoisted binary directly: in Yarn
+      # Berry `yarn cypress` resolves to a script name, and Cypress is a workspace (example)
+      # dependency, not a root one.
       - run: node_modules/.bin/cypress install
       # On PRs, build only affected packages unless 'ci:full' label is present.
       # On master events (push/workflow_dispatch), build all packages. (see #2026)
@@ -117,9 +124,15 @@ jobs:
           path: |
             node_modules
             .yarn
-            ~/.cache/Cypress
           key: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
+      # Restore the Cypress binary saved by the build job (same key). e2e tests (yarn e2e)
+      # launch Cypress, which needs its binary present in ~/.cache/Cypress.
+      - uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: cypress-${{ runner.os }}-
       - uses: actions/download-artifact@v8
         with:
           name: dist
@@ -162,7 +175,6 @@ jobs:
           path: |
             node_modules
             .yarn
-            ~/.cache/Cypress
           key: deps-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
       - uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,15 @@ jobs:
           key: yarn-dl-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-dl-${{ runner.os }}-
       - run: yarn --immutable
+      # Cypress downloads its binary to ~/.cache/Cypress via a postinstall script, but that
+      # script is skipped when yarn restores build-state from a prior cache (restore-keys
+      # serves the previous yarn.lock's cache on any dep change). The binary then never
+      # re-downloads on a Cypress version bump, so integration jobs fail with "the Cypress
+      # binary is missing" for the new version. `cypress install` downloads the binary for the
+      # resolved version and is a no-op if already present, guaranteeing the saved cache holds
+      # the matching binary regardless of restore-key fallback. See #2293 (bump merged with no
+      # e2e run) and https://docs.cypress.io/app/continuous-integration/overview.
+      - run: yarn cypress install
       # On PRs, build only affected packages unless 'ci:full' label is present.
       # On master events (push/workflow_dispatch), build all packages. (see #2026)
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
       # resolved version and is a no-op if already present, guaranteeing the saved cache holds
       # the matching binary regardless of restore-key fallback. See #2293 (bump merged with no
       # e2e run) and https://docs.cypress.io/app/continuous-integration/overview.
-      - run: yarn cypress install
+      # Invoke the hoisted binary directly: in Yarn Berry `yarn cypress` resolves to a script
+      # name, and Cypress is a workspace (example) dependency, not a root one.
+      - run: node_modules/.bin/cypress install
       # On PRs, build only affected packages unless 'ci:full' label is present.
       # On master events (push/workflow_dispatch), build all packages. (see #2026)
       - run: |

--- a/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
@@ -35,7 +35,7 @@
     "@eslint/js": "10.0.1",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.15.0",
     "eslint": "10.5.0",
     "puppeteer": "25.1.0",
     "typescript": "6.0.3",

--- a/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
@@ -35,7 +35,7 @@
     "@eslint/js": "10.0.1",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "puppeteer": "25.1.0",
     "typescript": "6.0.3",

--- a/examples/custom-esbuild/sanity-esbuild-app/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app/package.json
@@ -35,7 +35,7 @@
     "@eslint/js": "10.0.1",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.15.0",
     "eslint": "10.5.0",
     "puppeteer": "25.1.0",
     "typescript": "6.0.3",

--- a/examples/custom-esbuild/sanity-esbuild-app/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app/package.json
@@ -35,7 +35,7 @@
     "@eslint/js": "10.0.1",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "puppeteer": "25.1.0",
     "typescript": "6.0.3",

--- a/examples/custom-webpack/full-cycle-app/package.json
+++ b/examples/custom-webpack/full-cycle-app/package.json
@@ -35,7 +35,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "html-webpack-plugin": "5.6.7",
     "jasmine-core": "6.3.0",

--- a/examples/custom-webpack/full-cycle-app/package.json
+++ b/examples/custom-webpack/full-cycle-app/package.json
@@ -35,7 +35,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.15.0",
     "eslint": "10.5.0",
     "html-webpack-plugin": "5.6.7",
     "jasmine-core": "6.3.0",

--- a/examples/custom-webpack/sanity-app-esm/package.json
+++ b/examples/custom-webpack/sanity-app-esm/package.json
@@ -34,7 +34,7 @@
     "@cypress/schematic": "5.0.0",
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",
     "karma-chrome-launcher": "3.2.0",

--- a/examples/custom-webpack/sanity-app-esm/package.json
+++ b/examples/custom-webpack/sanity-app-esm/package.json
@@ -34,7 +34,7 @@
     "@cypress/schematic": "5.0.0",
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
-    "cypress": "15.16.0",
+    "cypress": "15.15.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",
     "karma-chrome-launcher": "3.2.0",

--- a/examples/custom-webpack/sanity-app/package.json
+++ b/examples/custom-webpack/sanity-app/package.json
@@ -35,7 +35,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",

--- a/examples/custom-webpack/sanity-app/package.json
+++ b/examples/custom-webpack/sanity-app/package.json
@@ -35,7 +35,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.15.0",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",

--- a/examples/jest/multiple-apps/package.json
+++ b/examples/jest/multiple-apps/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "30.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.15.0",
     "eslint": "10.5.0",
     "jest": "30.4.2",
     "jest-environment-jsdom": "30.4.1",

--- a/examples/jest/multiple-apps/package.json
+++ b/examples/jest/multiple-apps/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "30.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "jest": "30.4.2",
     "jest-environment-jsdom": "30.4.1",

--- a/examples/jest/simple-app/package.json
+++ b/examples/jest/simple-app/package.json
@@ -38,7 +38,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.15.0",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "jest": "30.4.2",

--- a/examples/jest/simple-app/package.json
+++ b/examples/jest/simple-app/package.json
@@ -38,7 +38,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "jest": "30.4.2",

--- a/examples/timestamp/package.json
+++ b/examples/timestamp/package.json
@@ -37,7 +37,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.15.0",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",

--- a/examples/timestamp/package.json
+++ b/examples/timestamp/package.json
@@ -37,7 +37,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9200,9 +9200,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:15.17.0":
-  version: 15.17.0
-  resolution: "cypress@npm:15.17.0"
+"cypress@npm:15.16.0":
+  version: 15.16.0
+  resolution: "cypress@npm:15.16.0"
   dependencies:
     "@cypress/request": "npm:^4.0.0"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -9245,7 +9245,7 @@ __metadata:
     yauzl: "npm:^3.3.1"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/4f8c38b075ba0f470d948fe9d705b3afc9d87f8a5e7e8592eaef88ae040ed42d3076fadf04c1eb1ef4806b3e9258f8daea14c2b1e05bf159530ad0e23d822d04
+  checksum: 10c0/9cee32e8cfc5e5f245ecea1ee9cfd1a9217b052bd88c42a1980986ee58eb3433c1f3be8a04e97e45161fae562fd4cc6e95746727e0263575c093bf2996232e93
   languageName: node
   linkType: hard
 
@@ -11063,7 +11063,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     html-webpack-plugin: "npm:5.6.7"
     jasmine-core: "npm:6.3.0"
@@ -14460,7 +14460,7 @@ __metadata:
     "@types/jest": "npm:30.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     jest: "npm:30.4.2"
     jest-environment-jsdom: "npm:30.4.1"
@@ -16764,7 +16764,7 @@ __metadata:
     "@cypress/schematic": "npm:5.0.0"
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"
     karma-chrome-launcher: "npm:3.2.0"
@@ -16801,7 +16801,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"
@@ -16839,7 +16839,7 @@ __metadata:
     "@eslint/js": "npm:10.0.1"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     puppeteer: "npm:25.1.0"
     rxjs: "npm:7.8.2"
@@ -16872,7 +16872,7 @@ __metadata:
     "@eslint/js": "npm:10.0.1"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     puppeteer: "npm:25.1.0"
     rxjs: "npm:7.8.2"
@@ -17308,7 +17308,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     jest: "npm:30.4.2"
@@ -18194,7 +18194,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9200,9 +9200,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:15.16.0":
-  version: 15.16.0
-  resolution: "cypress@npm:15.16.0"
+"cypress@npm:15.15.0":
+  version: 15.15.0
+  resolution: "cypress@npm:15.15.0"
   dependencies:
     "@cypress/request": "npm:^4.0.0"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -9224,6 +9224,7 @@ __metadata:
     eventemitter2: "npm:6.4.7"
     execa: "npm:4.1.0"
     executable: "npm:^4.1.1"
+    extract-zip: "npm:2.0.1"
     fs-extra: "npm:^9.1.0"
     hasha: "npm:5.2.2"
     is-installed-globally: "npm:~0.4.0"
@@ -9242,10 +9243,10 @@ __metadata:
     tree-kill: "npm:1.2.2"
     tslib: "npm:1.14.1"
     untildify: "npm:^4.0.0"
-    yauzl: "npm:^3.3.1"
+    yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/9cee32e8cfc5e5f245ecea1ee9cfd1a9217b052bd88c42a1980986ee58eb3433c1f3be8a04e97e45161fae562fd4cc6e95746727e0263575c093bf2996232e93
+  checksum: 10c0/991d19140f86dbe02fd52300eccb04d1b33ce646a0c4db10e2fb7c09e144aa67b26b12c67501305756c5220ff63cb927b845cb63a2346afeb86a03bf3265d979
   languageName: node
   linkType: hard
 
@@ -10600,7 +10601,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:^2.0.1":
+"extract-zip@npm:2.0.1, extract-zip@npm:^2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
   dependencies:
@@ -11063,7 +11064,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.15.0"
     eslint: "npm:10.5.0"
     html-webpack-plugin: "npm:5.6.7"
     jasmine-core: "npm:6.3.0"
@@ -14460,7 +14461,7 @@ __metadata:
     "@types/jest": "npm:30.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.15.0"
     eslint: "npm:10.5.0"
     jest: "npm:30.4.2"
     jest-environment-jsdom: "npm:30.4.1"
@@ -16764,7 +16765,7 @@ __metadata:
     "@cypress/schematic": "npm:5.0.0"
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.15.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"
     karma-chrome-launcher: "npm:3.2.0"
@@ -16801,7 +16802,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.15.0"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"
@@ -16839,7 +16840,7 @@ __metadata:
     "@eslint/js": "npm:10.0.1"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.15.0"
     eslint: "npm:10.5.0"
     puppeteer: "npm:25.1.0"
     rxjs: "npm:7.8.2"
@@ -16872,7 +16873,7 @@ __metadata:
     "@eslint/js": "npm:10.0.1"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.15.0"
     eslint: "npm:10.5.0"
     puppeteer: "npm:25.1.0"
     rxjs: "npm:7.8.2"
@@ -17308,7 +17309,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.15.0"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     jest: "npm:30.4.2"
@@ -18194,7 +18195,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.15.0"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"
@@ -19925,15 +19926,6 @@ __metadata:
     buffer-crc32: "npm:~0.2.3"
     fd-slicer: "npm:~1.1.0"
   checksum: 10c0/f265002af7541b9ec3589a27f5fb8f11cf348b53cc15e2751272e3c062cd73f3e715bc72d43257de71bbaecae446c3f1b14af7559e8ab0261625375541816422
-  languageName: node
-  linkType: hard
-
-"yauzl@npm:^3.3.1":
-  version: 3.4.0
-  resolution: "yauzl@npm:3.4.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10c0/17a98c42c0065e8af429eb8a61f7a0e4562181ed54080366b838f34f741b6829f167f804787c86b7646bb042707f35871739f053de0548285e405a2eae4da025
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Throwaway validation branch for the Cypress cache fix (#2305). Downgrades Cypress 15.17.0 -> 15.16.0 against a warm cache that holds 15.17.0, to prove the binary served matches the lockfile and does not snowball. Will be closed without merging.