### PR TITLE
chore(ci): exclude Cypress binary from the broad yarn-dl cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,14 @@ jobs:
       - uses: actions/cache@v5
         if: steps.deps-cache.outputs.cache-hit != 'true'
         with:
-          path: ~/.cache
+          # Scope to corepack's download dir only (~/.cache/node holds the Yarn release).
+          # The broad ~/.cache also contains ~/.cache/Cypress, which has its own version-keyed
+          # cache (below) restored by the integration jobs; caching it here too would duplicate
+          # the ~200MB binary that no job restores from this cache, wasting the repo's Actions
+          # cache budget and risking eviction of the dedicated cypress cache. (A `!~/.cache/Cypress`
+          # exclude does NOT work — actions/cache doesn't resolve ~ in negative patterns — so
+          # narrow with a positive path instead.)
+          path: ~/.cache/node
           key: yarn-dl-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-dl-${{ runner.os }}-
       # The Cypress binary (~/.cache/Cypress/<version>) is cached separately from node_modules,


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features) — N/A, CI cache optimization (validated via a forced deps-cache-miss run)
- [ ] Docs have been added / updated (for bug fixes / features) — N/A (rationale inline)

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

After #2305 the Cypress binary has its own version-keyed cache (`cypress-<os>-<lockhash>`), restored by the integration jobs. But the fallback yarn-download cache still uses `path: ~/.cache`, whose glob also sweeps up `~/.cache/Cypress`. The ~200MB binary is therefore stored twice. The integration/publish jobs restore only the deps and cypress caches — never `~/.cache` — so the yarn-dl copy is never read; it just consumes the repo's 10GB Actions cache budget and can push the dedicated cypress cache toward eviction.

## What is the new behavior?

The yarn-dl cache path excludes `~/.cache/Cypress`. The binary is cached and delivered solely by its dedicated cache. No behavior change for the jobs that run Cypress.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Validated on a forced deps-cache-miss run (so the yarn-dl step actually executes): its save no longer includes `~/.cache/Cypress`, and the full e2e matrix stays green (binary delivered by the dedicated cache).
