### PR TITLE
test: yarn-dl Cypress exclusion validation (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,13 @@ jobs:
       - uses: actions/cache@v5
         if: steps.deps-cache.outputs.cache-hit != 'true'
         with:
-          path: ~/.cache
+          # Exclude ~/.cache/Cypress: the Cypress binary has its own version-keyed cache
+          # (below), restored by the integration jobs. This broad ~/.cache cache would
+          # otherwise duplicate the ~200MB binary that no job restores from here, wasting the
+          # repo's Actions cache budget and risking eviction of the dedicated cypress cache.
+          path: |
+            ~/.cache
+            !~/.cache/Cypress
           key: yarn-dl-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-dl-${{ runner.os }}-
       # The Cypress binary (~/.cache/Cypress/<version>) is cached separately from node_modules,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,14 @@ jobs:
       - uses: actions/cache@v5
         if: steps.deps-cache.outputs.cache-hit != 'true'
         with:
-          # Exclude ~/.cache/Cypress: the Cypress binary has its own version-keyed cache
-          # (below), restored by the integration jobs. This broad ~/.cache cache would
-          # otherwise duplicate the ~200MB binary that no job restores from here, wasting the
-          # repo's Actions cache budget and risking eviction of the dedicated cypress cache.
-          path: |
-            ~/.cache
-            !~/.cache/Cypress
+          # Scope to corepack's download dir only (~/.cache/node holds the Yarn release).
+          # The broad ~/.cache also contains ~/.cache/Cypress, which has its own version-keyed
+          # cache (below) restored by the integration jobs; caching it here too would duplicate
+          # the ~200MB binary that no job restores from this cache, wasting the repo's Actions
+          # cache budget and risking eviction of the dedicated cypress cache. (A `!~/.cache/Cypress`
+          # exclude does NOT work — actions/cache doesn't resolve ~ in negative patterns — so
+          # narrow with a positive path instead.)
+          path: ~/.cache/node
           key: yarn-dl-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-dl-${{ runner.os }}-
       # The Cypress binary (~/.cache/Cypress/<version>) is cached separately from node_modules,

--- a/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
@@ -35,7 +35,7 @@
     "@eslint/js": "10.0.1",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.14.2",
     "eslint": "10.5.0",
     "puppeteer": "25.1.0",
     "typescript": "6.0.3",

--- a/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app-esm/package.json
@@ -35,7 +35,7 @@
     "@eslint/js": "10.0.1",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "puppeteer": "25.1.0",
     "typescript": "6.0.3",

--- a/examples/custom-esbuild/sanity-esbuild-app/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app/package.json
@@ -35,7 +35,7 @@
     "@eslint/js": "10.0.1",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.14.2",
     "eslint": "10.5.0",
     "puppeteer": "25.1.0",
     "typescript": "6.0.3",

--- a/examples/custom-esbuild/sanity-esbuild-app/package.json
+++ b/examples/custom-esbuild/sanity-esbuild-app/package.json
@@ -35,7 +35,7 @@
     "@eslint/js": "10.0.1",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "puppeteer": "25.1.0",
     "typescript": "6.0.3",

--- a/examples/custom-webpack/full-cycle-app/package.json
+++ b/examples/custom-webpack/full-cycle-app/package.json
@@ -35,7 +35,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "html-webpack-plugin": "5.6.7",
     "jasmine-core": "6.3.0",

--- a/examples/custom-webpack/full-cycle-app/package.json
+++ b/examples/custom-webpack/full-cycle-app/package.json
@@ -35,7 +35,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.14.2",
     "eslint": "10.5.0",
     "html-webpack-plugin": "5.6.7",
     "jasmine-core": "6.3.0",

--- a/examples/custom-webpack/sanity-app-esm/package.json
+++ b/examples/custom-webpack/sanity-app-esm/package.json
@@ -34,7 +34,7 @@
     "@cypress/schematic": "5.0.0",
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
-    "cypress": "15.16.0",
+    "cypress": "15.14.2",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",
     "karma-chrome-launcher": "3.2.0",

--- a/examples/custom-webpack/sanity-app-esm/package.json
+++ b/examples/custom-webpack/sanity-app-esm/package.json
@@ -34,7 +34,7 @@
     "@cypress/schematic": "5.0.0",
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",
     "karma-chrome-launcher": "3.2.0",

--- a/examples/custom-webpack/sanity-app/package.json
+++ b/examples/custom-webpack/sanity-app/package.json
@@ -35,7 +35,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.14.2",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",

--- a/examples/custom-webpack/sanity-app/package.json
+++ b/examples/custom-webpack/sanity-app/package.json
@@ -35,7 +35,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",

--- a/examples/jest/multiple-apps/package.json
+++ b/examples/jest/multiple-apps/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "30.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.14.2",
     "eslint": "10.5.0",
     "jest": "30.4.2",
     "jest-environment-jsdom": "30.4.1",

--- a/examples/jest/multiple-apps/package.json
+++ b/examples/jest/multiple-apps/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "30.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "jest": "30.4.2",
     "jest-environment-jsdom": "30.4.1",

--- a/examples/jest/simple-app/package.json
+++ b/examples/jest/simple-app/package.json
@@ -38,7 +38,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.14.2",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "jest": "30.4.2",

--- a/examples/jest/simple-app/package.json
+++ b/examples/jest/simple-app/package.json
@@ -38,7 +38,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "jest": "30.4.2",

--- a/examples/timestamp/package.json
+++ b/examples/timestamp/package.json
@@ -37,7 +37,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.17.0",
+    "cypress": "15.16.0",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",

--- a/examples/timestamp/package.json
+++ b/examples/timestamp/package.json
@@ -37,7 +37,7 @@
     "@types/jasmine": "6.0.0",
     "@types/node": "24.13.2",
     "angular-eslint": "22.0.0",
-    "cypress": "15.16.0",
+    "cypress": "15.14.2",
     "eslint": "10.5.0",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9191,9 +9191,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:15.17.0":
-  version: 15.17.0
-  resolution: "cypress@npm:15.17.0"
+"cypress@npm:15.16.0":
+  version: 15.16.0
+  resolution: "cypress@npm:15.16.0"
   dependencies:
     "@cypress/request": "npm:^4.0.0"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -9236,7 +9236,7 @@ __metadata:
     yauzl: "npm:^3.3.1"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/4f8c38b075ba0f470d948fe9d705b3afc9d87f8a5e7e8592eaef88ae040ed42d3076fadf04c1eb1ef4806b3e9258f8daea14c2b1e05bf159530ad0e23d822d04
+  checksum: 10c0/9cee32e8cfc5e5f245ecea1ee9cfd1a9217b052bd88c42a1980986ee58eb3433c1f3be8a04e97e45161fae562fd4cc6e95746727e0263575c093bf2996232e93
   languageName: node
   linkType: hard
 
@@ -11054,7 +11054,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     html-webpack-plugin: "npm:5.6.7"
     jasmine-core: "npm:6.3.0"
@@ -14451,7 +14451,7 @@ __metadata:
     "@types/jest": "npm:30.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     jest: "npm:30.4.2"
     jest-environment-jsdom: "npm:30.4.1"
@@ -16755,7 +16755,7 @@ __metadata:
     "@cypress/schematic": "npm:5.0.0"
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"
     karma-chrome-launcher: "npm:3.2.0"
@@ -16792,7 +16792,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"
@@ -16830,7 +16830,7 @@ __metadata:
     "@eslint/js": "npm:10.0.1"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     puppeteer: "npm:25.1.0"
     rxjs: "npm:7.8.2"
@@ -16863,7 +16863,7 @@ __metadata:
     "@eslint/js": "npm:10.0.1"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     puppeteer: "npm:25.1.0"
     rxjs: "npm:7.8.2"
@@ -17299,7 +17299,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     jest: "npm:30.4.2"
@@ -18185,7 +18185,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.17.0"
+    cypress: "npm:15.16.0"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2589,9 +2589,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cypress/request@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "@cypress/request@npm:4.0.1"
+"@cypress/request@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@cypress/request@npm:3.0.10"
   dependencies:
     aws-sign2: "npm:~0.7.0"
     aws4: "npm:^1.8.0"
@@ -2606,11 +2606,12 @@ __metadata:
     json-stringify-safe: "npm:~5.0.1"
     mime-types: "npm:~2.1.19"
     performance-now: "npm:^2.1.0"
-    qs: "npm:^6.15.2"
+    qs: "npm:~6.14.1"
     safe-buffer: "npm:^5.1.2"
     tough-cookie: "npm:^5.0.0"
     tunnel-agent: "npm:^0.6.0"
-  checksum: 10c0/266648f03ebf3645ccfb3f17dceb1e8ce95a456a79e7f958ee2165ef84ce5bfdbea2904fdd5b21d6301e7abeb72e35b5dec33393502501758cd20df86eb2e943
+    uuid: "npm:^8.3.2"
+  checksum: 10c0/93da9754315261474deeefff235ed0397811d49f03f2dfcebd01aff12b75fd58e104b0c7fd3d720e1ebc51d73059e1f540db68c58bbda4612493610227ade710
   languageName: node
   linkType: hard
 
@@ -9191,11 +9192,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:15.16.0":
-  version: 15.16.0
-  resolution: "cypress@npm:15.16.0"
+"cypress@npm:15.14.2":
+  version: 15.14.2
+  resolution: "cypress@npm:15.14.2"
   dependencies:
-    "@cypress/request": "npm:^4.0.0"
+    "@cypress/request": "npm:^3.0.10"
     "@cypress/xvfb": "npm:^1.2.4"
     "@types/sinonjs__fake-timers": "npm:8.1.1"
     "@types/sizzle": "npm:^2.3.2"
@@ -9215,6 +9216,7 @@ __metadata:
     eventemitter2: "npm:6.4.7"
     execa: "npm:4.1.0"
     executable: "npm:^4.1.1"
+    extract-zip: "npm:2.0.1"
     fs-extra: "npm:^9.1.0"
     hasha: "npm:5.2.2"
     is-installed-globally: "npm:~0.4.0"
@@ -9233,10 +9235,10 @@ __metadata:
     tree-kill: "npm:1.2.2"
     tslib: "npm:1.14.1"
     untildify: "npm:^4.0.0"
-    yauzl: "npm:^3.3.1"
+    yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/9cee32e8cfc5e5f245ecea1ee9cfd1a9217b052bd88c42a1980986ee58eb3433c1f3be8a04e97e45161fae562fd4cc6e95746727e0263575c093bf2996232e93
+  checksum: 10c0/d68ddc88004739f3d08babb373c156c0c037f2ff4bf25ec2062755cdd77e62f653b4ceac97ee91e797fadc15597f3afdca834f984f34de35fcacf095e9b9c8a2
   languageName: node
   linkType: hard
 
@@ -10591,7 +10593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:^2.0.1":
+"extract-zip@npm:2.0.1, extract-zip@npm:^2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
   dependencies:
@@ -11054,7 +11056,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.14.2"
     eslint: "npm:10.5.0"
     html-webpack-plugin: "npm:5.6.7"
     jasmine-core: "npm:6.3.0"
@@ -14451,7 +14453,7 @@ __metadata:
     "@types/jest": "npm:30.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.14.2"
     eslint: "npm:10.5.0"
     jest: "npm:30.4.2"
     jest-environment-jsdom: "npm:30.4.1"
@@ -15949,12 +15951,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.14.0, qs@npm:^6.14.1, qs@npm:^6.15.2, qs@npm:~6.15.1":
+"qs@npm:^6.14.0, qs@npm:^6.14.1, qs@npm:~6.15.1":
   version: 6.15.2
   resolution: "qs@npm:6.15.2"
   dependencies:
     side-channel: "npm:^1.1.0"
   checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
+  languageName: node
+  linkType: hard
+
+"qs@npm:~6.14.1":
+  version: 6.14.2
+  resolution: "qs@npm:6.14.2"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 10c0/646110124476fc9acf3c80994c8c3a0600cbad06a4ede1c9e93341006e8426d64e85e048baf8f0c4995f0f1bf0f37d1f3acc5ec1455850b81978792969a60ef6
   languageName: node
   linkType: hard
 
@@ -16755,7 +16766,7 @@ __metadata:
     "@cypress/schematic": "npm:5.0.0"
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.14.2"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"
     karma-chrome-launcher: "npm:3.2.0"
@@ -16792,7 +16803,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.14.2"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"
@@ -16830,7 +16841,7 @@ __metadata:
     "@eslint/js": "npm:10.0.1"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.14.2"
     eslint: "npm:10.5.0"
     puppeteer: "npm:25.1.0"
     rxjs: "npm:7.8.2"
@@ -16863,7 +16874,7 @@ __metadata:
     "@eslint/js": "npm:10.0.1"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.14.2"
     eslint: "npm:10.5.0"
     puppeteer: "npm:25.1.0"
     rxjs: "npm:7.8.2"
@@ -17299,7 +17310,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.14.2"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     jest: "npm:30.4.2"
@@ -18185,7 +18196,7 @@ __metadata:
     "@types/jasmine": "npm:6.0.0"
     "@types/node": "npm:24.13.2"
     angular-eslint: "npm:22.0.0"
-    cypress: "npm:15.16.0"
+    cypress: "npm:15.14.2"
     eslint: "npm:10.5.0"
     jasmine-core: "npm:6.3.0"
     karma: "npm:6.4.4"
@@ -19916,15 +19927,6 @@ __metadata:
     buffer-crc32: "npm:~0.2.3"
     fd-slicer: "npm:~1.1.0"
   checksum: 10c0/f265002af7541b9ec3589a27f5fb8f11cf348b53cc15e2751272e3c062cd73f3e715bc72d43257de71bbaecae446c3f1b14af7559e8ab0261625375541816422
-  languageName: node
-  linkType: hard
-
-"yauzl@npm:^3.3.1":
-  version: 3.4.0
-  resolution: "yauzl@npm:3.4.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10c0/17a98c42c0065e8af429eb8a61f7a0e4562181ed54080366b838f34f741b6829f167f804787c86b7646bb042707f35871739f053de0548285e405a2eae4da025
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Validates #2310. Bumps Cypress to force a deps-cache miss so the yarn-dl (`~/.cache`) step runs. Checks that its save excludes ~/.cache/Cypress and e2e stays green. Will be closed without merging.