### PR TITLE
fix(scripts): propagate Angular major bump into library sub-projects

### DIFF
--- a/scripts/update-example.js
+++ b/scripts/update-example.js
@@ -1,4 +1,6 @@
 const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 const package = require(`${process.cwd()}/package.json`);
 
 // Accepts either an integer major (e.g. `22`), an explicit version
@@ -134,12 +136,59 @@ const updateNonAngularApp = () => {
   }
 };
 
+// `ng update` only rewrites the workspace's own package.json. ng-packagr library
+// sub-projects (projects/*/package.json) carry their own Angular peerDependencies,
+// which ng update never touches — so a major bump strands them on the previous major
+// while the host app moves forward. Renovate later catches the gap and files a
+// straggler PR (this is what #2308 was). Propagate the host's freshly-resolved
+// @angular/* versions into any library sub-project so the whole example moves majors
+// atomically. Copies the host's exact spec verbatim, so caret/exact/prerelease ranges
+// are preserved as-is.
+const updateLibrarySubProjects = () => {
+  const projectsDir = path.join(process.cwd(), 'projects');
+  if (!fs.existsSync(projectsDir)) return;
+
+  const host = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+  const hostDeps = { ...host.dependencies, ...host.devDependencies };
+  // @angular/* ship in lockstep on one version train, so @angular/core's resolved
+  // spec is the right value for every @angular/* entry in the sub-project.
+  const targetSpec = hostDeps['@angular/core'];
+  if (!targetSpec) {
+    console.warn('⚠️  No @angular/core in host package.json; skipping sub-project update.');
+    return;
+  }
+
+  for (const entry of fs.readdirSync(projectsDir)) {
+    const pkgPath = path.join(projectsDir, entry, 'package.json');
+    if (!fs.existsSync(pkgPath)) continue;
+
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    let changed = false;
+    for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      const deps = pkg[depType];
+      if (!deps) continue;
+      for (const name of Object.keys(deps)) {
+        if (name.startsWith('@angular/') && deps[name] !== targetSpec) {
+          console.log(`  ${entry}/${depType}: ${name} ${deps[name]} -> ${targetSpec}`);
+          deps[name] = targetSpec;
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+      console.log(`✅ Updated sub-project ${path.relative(process.cwd(), pkgPath)}`);
+    }
+  }
+};
+
 const updateExample = () => {
   console.log('Current working directory:', process.cwd());
   if (package.name === 'bazel-example') {
     updateNonAngularApp();
   } else {
     runNgUpdate();
+    updateLibrarySubProjects();
   }
 };
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

> Verified by dry-running the propagation logic against `examples/jest/multiple-apps`: it rewrites exactly the two stranded `my-shared-library` peerDeps and nothing else. No automated test harness exists for `scripts/update-example.js` (it shells out to `ng update`), so a unit test would test almost nothing but the file-walk; the dry-run is the meaningful verification here.

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`ng update` only rewrites a workspace's own `package.json`. ng-packagr **library** sub-projects (`projects/*/package.json`) carry their own Angular `peerDependencies`, which `ng update` never touches. So during an Angular major migration (`yarn update:examples`), the host app moves forward but any library sub-project is stranded on the previous major.

This is exactly what happened to `examples/jest/multiple-apps/projects/my-shared-library`: it stayed on `21.2.17` after the v22 migration, and Renovate had to file a separate straggler PR (#2308) to clean it up. It doesn't break the build, but it leaves the repo internally inconsistent after every major and generates avoidable Renovate churn.

Issue Number: N/A

## What is the new behavior?

`scripts/update-example.js` now runs `updateLibrarySubProjects()` after `ng update`. It walks any `projects/*/package.json`, and for every `@angular/*` entry in `dependencies` / `devDependencies` / `peerDependencies` it copies the host app's freshly-resolved `@angular/core` spec **verbatim** (so caret / exact / prerelease formats are preserved). The whole example now moves majors atomically.

Scoped narrowly: only `@angular/*` keys, only when a `projects/` dir exists, only in the `ng update` path (bazel example is untouched). Today that's a single file, but the logic generalizes to any future library fixture.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Build automation only — no published package or builder behavior changes.
