### PR TITLE
fix(jest): stop pinning jest-preset-angular in ng-add; resolve it transitively

### DIFF
--- a/packages/jest/src/schematics/ng-add/index.spec.ts
+++ b/packages/jest/src/schematics/ng-add/index.spec.ts
@@ -18,8 +18,10 @@ describe('jest ng-add (no Karma)', () => {
     const pkg = JSON.parse(out.readText('/package.json'));
     expect(pkg.devDependencies['@angular-builders/jest']).toBeDefined();
     expect(pkg.devDependencies['jest']).toBeDefined();
-    expect(pkg.devDependencies['jest-preset-angular']).toBeDefined();
     expect(pkg.devDependencies['jest-environment-jsdom']).toBeDefined();
+    // jest-preset-angular resolves transitively from @angular-builders/jest, so ng-add does
+    // not add it to the consuming project's devDependencies.
+    expect(pkg.devDependencies['jest-preset-angular']).toBeUndefined();
     expect(r.tasks.length).toBeGreaterThan(0);
   });
 

--- a/packages/jest/src/schematics/ng-add/index.ts
+++ b/packages/jest/src/schematics/ng-add/index.ts
@@ -16,10 +16,14 @@ import { NgAddOptions } from './schema';
 
 const JEST_BUILDER = '@angular-builders/jest:run';
 
+// jest-preset-angular is intentionally NOT listed here: it is a direct dependency of
+// @angular-builders/jest, so under a hoisting installer (Yarn node-modules linker, default
+// npm) it resolves transitively from the builder and the bare `preset: 'jest-preset-angular'`
+// specifier works without the consuming project declaring it. Pinning it here only created a
+// second, independently-versioned copy that drifted from the builder's own dependency.
 const JEST_STACK: Array<[name: string, version: string]> = [
   ['@angular-builders/jest', '^22.0.0'],
   ['jest', '^30.0.0'],
-  ['jest-preset-angular', '^17.0.0'],
   ['jest-environment-jsdom', '^30.0.0'],
 ];
 


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`ng add @angular-builders/jest` writes a hard-coded `jest-preset-angular` version into the consuming project's `devDependencies` (the `JEST_STACK` pin in `packages/jest/src/schematics/ng-add/index.ts`).

This pin is redundant and was introduced only recently — in #2267 (the "ng add / ng update schematics" feature, 2026-06-09), inside the current v22 major. `jest-preset-angular` has been a direct **`dependency`** of `@angular-builders/jest` since the builder's inception (it was `^5.2.3` in 2018) — never a peer — so under a hoisting installer (Yarn node-modules linker, default npm) it resolves transitively from the builder and the bare `preset: 'jest-preset-angular'` specifier works without the project declaring it. The `examples/jest/*` apps already rely on exactly this: they depend only on `@angular-builders/jest` and never declare the preset.

The redundant pin immediately drifted: #2313 bumped the builder's own dependency to `^17` while the ng-add pin stayed `^16`, so a fresh `ng add` would scaffold `^16` into a user's project while the builder runs against `^17` — two preset copies in the user's tree.

## What is the new behavior?

`jest-preset-angular` is removed from `JEST_STACK`. ng-add no longer re-declares it; it resolves transitively from `@angular-builders/jest`, restoring the long-standing behavior that predates #2267 and eliminating the version-sync burden permanently. The ng-add spec is updated to assert the preset is **not** added directly. `jest` (a peer dep) and `jest-environment-jsdom` are still added, as before.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

`ng add` is a one-time scaffold: existing users keep `jest-preset-angular` in their `package.json` untouched, so no project requires any migration. This restores the pre-#2267 behavior — it removes a redundant pin that should never have been added in this major, not a feature anyone has depended on.

Note (pre-existing, not a regression introduced here): on a strict/non-hoisting installer (pnpm, Yarn PnP, npm `--install-strategy=nested`), a transitive dependency of the builder is not resolvable from the project root, so such users would need `jest-preset-angular` in their own `devDependencies`. That was already true before #2267 added the short-lived pin.

## Other information

Companion to #2313 (already merged), which bumped the existing pin to `^17` so that change is internally consistent on its own. All 14 ng-add unit tests pass; full package build (6/6) is green locally.
