### PR TITLE
fix(scripts): pin bazel example Angular CLI exactly to stop Renovate divergence

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
       "rangeStrategy": "replace"
     },
     {
+      "description": "Pin every example dependency to an exact version. Examples are test fixtures, not published packages, so they must resolve deterministically. A loose range here (e.g. bazel's `@angular/cli: \"22\"`) is pinned to the *currently-resolved* version on the next run instead of bumped to latest — so that one example lags every other by a patch and fragments the dep tree (duplicate @angular-devkit/architect). This broke CI and required #2307; the recurrence source (the `yarn add` path in scripts/update-example.js) now pins with `--exact`. Keep example specs exact so this rule only ever has to maintain pins, never repair loose ranges.",
       "matchPaths": ["examples/**"],
       "rangeStrategy": "pin"
     },

--- a/scripts/update-example.js
+++ b/scripts/update-example.js
@@ -122,7 +122,15 @@ const updateNonAngularApp = () => {
   checkNodeVersion();
 
   try {
-    execSync(`yarn add -D @angular/cli@${spec}`, {
+    // `--exact` is required so a bare-major arg (e.g. `22`) lands an exact pin
+    // (`22.0.3`) rather than yarn's default caret/loose range (`22`/`^22.0.0`).
+    // Every other example is pinned exactly by `ng update`; this path is the only
+    // one that goes through `yarn add`. A loose range here diverges under Renovate's
+    // `rangeStrategy: pin` (examples/**): it gets *pinned to the currently-resolved
+    // version* instead of bumped to latest, so bazel lags every other example by a
+    // patch and fragments the dep tree (duplicate @angular-devkit/architect). This
+    // is what broke CI and required #2307.
+    execSync(`yarn add -D --exact @angular/cli@${spec}`, {
       cwd: process.cwd(),
       stdio: 'inherit',
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

> No automated test is added: the change only affects the manual `yarn update:example` codepath (which shells out to `yarn add`) and a Renovate-config comment. Both are exercised end-to-end by the next Angular bump. The renovate.json change is documentation-only (a `description` field). I validated `renovate.json` parses as JSON, `scripts/update-example.js` passes `node --check`, and both files pass Prettier.

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Motivating incident: #2307.

The `bazel` example is the **only** example whose Angular CLI is updated via `yarn add` (the `updateNonAngularApp` path in `scripts/update-example.js`) rather than `ng update` — `ng update` doesn't apply to a non-Angular app. Every other example goes through `ng update`, which writes an **exact** pin (e.g. `"22.0.3"`).

`yarn add -D @angular/cli@<spec>` with a bare major arg (e.g. `22`) writes a **loose** range. That is exactly how commit `2cb9a564` ("update bazel-example to Angular CLI 22") landed `"@angular/cli": "22"` while every other example stayed exact-pinned.

`renovate.json` applies `rangeStrategy: pin` to `examples/**`. For a loose range, "pin" means **pin to the currently-resolved version**, not "bump to latest". So when the Angular `22.0.0 → 22.0.3` update ran, the exact-pinned examples bumped to `22.0.3` (update type `patch`), but bazel's `"22"` was *pinned to its currently-resolved `22.0.0`* (update type `pin`) — both inside the **same** grouped Renovate PR (#2307 body literally shows two `@angular/cli` rows: `22.0.0 → 22.0.3` patch, and `22 → 22.0.0` pin).

Result: bazel lagged every other example by a patch, producing a duplicate `@angular-devkit/architect` and forcing `@angular/cli` into the uncached `examples/bazel/node_modules` — which broke CI. #2307 hand-corrected bazel to `22.0.3`, but did **not** fix the source: the next bare-major update would write a loose range into bazel again.

Note: grouping was already in effect (the existing `angular` `packageRules` entry matches `@angular/**`, including `@angular/cli`), so the divergence happened *within one PR* and is **not** a grouping problem — it is purely the loose-range-vs-exact-pin interaction with `rangeStrategy: pin`. A Renovate config change alone cannot robustly prevent it; the fix has to stop the loose range from being written.

## What is the new behavior?

- `scripts/update-example.js`: the `updateNonAngularApp` path now runs `yarn add -D --exact @angular/cli@<spec>`, so the bazel example is pinned to an exact version just like every other example. This removes the structural recurrence — the source that re-introduced the loose range.
- `renovate.json`: added a `description` to the existing `examples/** → rangeStrategy: pin` rule documenting why example deps must stay exact-pinned and what goes wrong otherwise (matching the file's existing documented-rule style). Behavior unchanged — documentation only.

Verified that all current `examples/*/package.json` and `packages/*/package.json` Angular deps are consistent: every example is exact-pinned (`22.0.x`); no other loose `@angular/*` or `@angular-devkit/*` ranges exist in examples. The `packages/*` ranges (`^22.0.0`, `>=0.2200.0 < 0.2300.0`) are intentional and governed by the separate `packages/** → rangeStrategy: replace` rule.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Follow-up to #2307. No package versions change in this PR (all examples are already exact-pinned on master), so no lockfile change is needed.
