### PR TITLE
docs: record that master is PR-protected in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,8 @@ Lerna-Lite manages versioning and publishing. Packages use **independent version
 
 **MUST:** When creating a pull request, read `.github/PULL_REQUEST_TEMPLATE.md` and use its structure for the PR body. Fill in all sections: PR checklist, PR type, current behavior, new behavior, and breaking change flag.
 
+**MUST NEVER:** Push straight to `master`. A repository ruleset requires every change to arrive through a pull request and to pass the `ci-pass` status check. Jeb is a bypass actor, so a direct push **succeeds** and only reports the bypass in its output — the guard will not stop you, which is exactly why this is written down. This applies to documentation-only commits too. Note that `gh api repos/just-jeb/angular-builders/rules/branches/master` returns `[]` for a bypass actor, so an empty rules list is not evidence that master is unprotected.
+
 ## Local Failure Triage
 
 A failing local jest or build run here is **frequently environment contamination, not a


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: N/A

`master` is covered by a repository ruleset requiring every change to arrive via a
pull request with a passing `ci-pass` check. Nothing in `AGENTS.md` says so.

Because the repo owner is a bypass actor, a direct `git push origin master`
**succeeds** — it only mentions the bypass in its output. And
`gh api repos/just-jeb/angular-builders/rules/branches/master` returns `[]` for a
bypass actor, so checking for protection the obvious way reports none.

Between those two, an agent session has no signal that the rule exists. That is how
the preceding commit (`20642239`, the AGENTS.md local-failure-triage addition) landed
straight on master during a context migration.

## What is the new behavior?

A `MUST NEVER: Push straight to master` invariant, which states the ruleset, says
explicitly that the guard does not stop a bypass actor, notes that it covers
docs-only commits, and warns that an empty rules list is not evidence of an
unprotected branch.

`20642239` is left in place — its content is wanted, and rewriting already-pushed
history costs more than it fixes. This PR closes the knowledge gap that produced it,
and does so through the process it documents.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Committed with `--no-verify`. Husky could not resolve `lint-staged` after the branch
switch, and the documented fix (`yarn install`) cannot run right now:
`registry.npmjs.org` is unreachable from this machine, while the Cloudsmith proxy
answers 401. AGENTS.md's own Local Failure Triage section names that as the one case
where `--no-verify` is appropriate. The change is a single prose block in a markdown
file, so nothing was skipped that matters — but it does want prettier's blessing from
CI.
